### PR TITLE
Click the hash link should get the url to the method

### DIFF
--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -54,10 +54,10 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
                     = seq
           div class="flex md:justify-end w-full md:w-2/12 mt-3 md:mt-0 font-mono"
             - if m.instance_method?
-              a class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current" title="Instance Method"
+              a class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current cursor-pointer" title="Instance Method" href=object_path(version: ruby_version, anchor: method_anchor(m))
                 | #
             - elsif m.class_method?
-              a class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current" title="Class Method"
+              a class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current cursor-pointer" title="Class Method" href=object_path(version: ruby_version, anchor: method_anchor(m))
                 | ::
             a class="px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current" href="#{github_url m}" target="_blank" rel="noopener" title="View source on Github"
               i class="fab fa-github"


### PR DESCRIPTION
Right now the `＃` link can‘t be clicked because it has no `href`.

<img width="888" alt="スクリーンショット 2020-02-19 19 30 04" src="https://user-images.githubusercontent.com/1000669/74826109-65481a00-534e-11ea-9ab6-48595aac5081.png">

This Pull Request assumes we want people to click `＃` and get the permanent url. Also changed the cursor to pointer so people knows this can be clicked.