### PR TITLE
Dramatically reduce allocations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   def ruby_version
     params[:version] || Rails.configuration.default_ruby_version

--- a/app/controllers/execute_controller.rb
+++ b/app/controllers/execute_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ExecuteController < ApplicationController
   def post
     data = HTTP.post(URI.join(ENV["CODERUNTIME_HOST"], "/run").to_s, json: {snippet: params[:snippet], version: ruby_version})

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GraphqlController < ApplicationController
   skip_before_action :verify_authenticity_token
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HomeController < ApplicationController
   before_action :enable_public_cache
 

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ObjectsController < ApplicationController
   rescue_from Elasticsearch::Persistence::Repository::DocumentNotFound, with: :not_found
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SearchController < ApplicationController
   MAX_SEARCH_QUERY_LENGTH = 255
 

--- a/app/graphql/ruby_api_schema.rb
+++ b/app/graphql/ruby_api_schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RubyApiSchema < GraphQL::Schema
   query Types::QueryType
 end

--- a/app/graphql/types/autocomplete_search_result_type.rb
+++ b/app/graphql/types/autocomplete_search_result_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class AutocompleteSearchResultType < Types::BaseObject
     field :text, String, null: false

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseEnum < GraphQL::Schema::Enum
   end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseField < GraphQL::Schema::Field
     def resolve_field(obj, args, ctx)

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseInputObject < GraphQL::Schema::InputObject
   end

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   module BaseInterface
     include GraphQL::Schema::Interface

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseObject < GraphQL::Schema::Object
   end

--- a/app/graphql/types/base_scalar.rb
+++ b/app/graphql/types/base_scalar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseScalar < GraphQL::Schema::Scalar
   end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class BaseUnion < GraphQL::Schema::Union
   end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class MutationType < Types::BaseObject
     # TODO: remove me

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class QueryType < Types::BaseObject
     field :rubyObject, Types::RubyObjectType, null: true, method: :ruby_object do

--- a/app/graphql/types/ruby_method_type.rb
+++ b/app/graphql/types/ruby_method_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class RubyMethodType < Types::BaseObject
     implements SearchResultType

--- a/app/graphql/types/ruby_object_type.rb
+++ b/app/graphql/types/ruby_object_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types
   class RubyObjectType < Types::BaseObject
     implements SearchResultType

--- a/app/graphql/types/search_result_type.rb
+++ b/app/graphql/types/search_result_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Types::SearchResultType
   include Types::BaseInterface
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SearchHelper
   def method_anchor(method)
     # See https://github.com/ruby/rdoc/blob/c64210219ec6c0f447b4c66c2c3556cfe462993f/lib/rdoc/method_attr.rb#L294

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 module SearchHelper
-  def method_anchor(method)
-    # See https://github.com/ruby/rdoc/blob/c64210219ec6c0f447b4c66c2c3556cfe462993f/lib/rdoc/method_attr.rb#L294
-    method_name = CGI.escape(method.name.gsub("-", "-2D")).tr("%", "-").sub(/^-/, "")
+  def escape_method_name(method_name)
+    (@escaped_method_names ||= {})[method_name] ||= begin
+      # See https://github.com/ruby/rdoc/blob/c64210219ec6c0f447b4c66c2c3556cfe462993f/lib/rdoc/method_attr.rb#L294
+      CGI.escape(method_name.gsub("-", "-2D")).tr("%", "-").sub(/^-/, "")
+    end
+  end
 
-    "method-#{method.instance_method? ? "i" : "c"}-#{method_name}"
+  def method_anchor(method)
+    "method-#{method.instance_method? ? "i" : "c"}-#{escape_method_name(method.name)}"
   end
 
   def result_url(result, version:)

--- a/app/models/ruby_method.rb
+++ b/app/models/ruby_method.rb
@@ -4,7 +4,7 @@ class RubyMethod
   attr_reader :body
 
   def initialize(body)
-    @body = HashWithIndifferentAccess.new(body).deep_symbolize_keys
+    @body = body
   end
 
   def name

--- a/app/models/ruby_object.rb
+++ b/app/models/ruby_object.rb
@@ -4,7 +4,7 @@ class RubyObject
   attr_reader :body
 
   def initialize(body)
-    @body = HashWithIndifferentAccess.new(body).deep_symbolize_keys
+    @body = body
   end
 
   def self.id_from_path(path)

--- a/app/repositories/ruby_object_repository.rb
+++ b/app/repositories/ruby_object_repository.rb
@@ -18,4 +18,9 @@ class RubyObjectRepository
   def self.repository_for_version(version)
     new(index_name: "ruby_objects_#{version}_#{Rails.env}")
   end
+
+  def deserialize(document)
+    document.deep_symbolize_keys!
+    klass.new(document[:_source])
+  end
 end

--- a/app/repositories/search_repository.rb
+++ b/app/repositories/search_repository.rb
@@ -82,14 +82,14 @@ class SearchRepository
   end
 
   def deserialize(document)
-    @klass = klass_for_document(document)
-    super
+    document.deep_symbolize_keys!
+    klass_for_document(document).new(document[:_source])
   end
 
   private
 
   def klass_for_document(document)
-    case document["_source"]["type"].to_sym
+    case document[:_source][:type].to_sym
     when :method
       RubyMethod
     when :object

--- a/app/services/ruby.rb
+++ b/app/services/ruby.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ruby
   CORE_CLASSES = {
     "String" => 1.5,

--- a/app/services/search/autocomplete.rb
+++ b/app/services/search/autocomplete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Search
   class Autocomplete
     def self.search(query, version:)

--- a/app/services/search/documentation.rb
+++ b/app/services/search/documentation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Search
   class Results
     attr_reader :query

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,3 +1,4 @@
+-# frozen_string_literal: true
 - description "Easily find and browse Ruby classes, modules and methods"
 - content_for :head do
   script type="application/ld+json"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,3 +1,4 @@
+-# frozen_string_literal: true
 header id="header" class="text-white bg-red-600 dark:bg-gray-700 flex items-center fixed top-0 inset-x-0 z-50 h-16"
   nav class="w-full max-w-screen-xl mx-auto" role="navigation" aria-label="main navigation"
     div class="flex items-center justify-between px-3"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,3 +1,4 @@
+-# frozen_string_literal: true
 doctype html
 html lang="en"
   head

--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -1,3 +1,4 @@
+-# frozen_string_literal: true
 - title @object.name
 - set_meta_tags canonical: object_url(object: @object.path, version: default_ruby_version) if default_ruby_version != ruby_version
 

--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -13,7 +13,7 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
             ul class="font-mono text-sm"
               - @object.ruby_methods.select(&:class_method?).sort_by(&:name).each do |m|
                 li
-                  = link_to object_path(version: ruby_version, anchor: method_anchor(m)), class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" do
+                  = link_to "##{method_anchor(m)}", class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" do
                     | :: #{m.name}
         - unless @object.ruby_methods.select(&:instance_method?).empty?
           div class="mb-3"
@@ -22,7 +22,7 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
             ul class="font-mono text-sm"
               - @object.ruby_methods.select(&:instance_method?).sort_by(&:name).each do |m|
                 li
-                  = link_to object_path(version: ruby_version, anchor: method_anchor(m)), class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" do
+                  = link_to "##{method_anchor(m)}", class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" do
                     | # #{m.name}
   div class="w-full mt-16 lg:mt-20 lg:w-3/4"
     div class="md:p-3 py-3"
@@ -47,9 +47,9 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
           div class="w-full md:w-10/12"
             - if m.call_sequence.empty?
               h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
-                = link_to m.name, object_path(version: ruby_version, anchor: method_anchor(m))
+                = link_to m.name, "##{method_anchor(m)}"
             - else
-              = link_to object_path(version: ruby_version, anchor: method_anchor(m)) do
+              = link_to "##{method_anchor(m)}" do
                 - m.call_sequence.each do |seq|
                   h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
                     = seq

--- a/app/views/search/index.html.slim
+++ b/app/views/search/index.html.slim
@@ -1,3 +1,4 @@
+-# frozen_string_literal: true
 - title search_query
 - noindex
 

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative "config/environment"

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'action_controller/railtie'

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative 'application'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # ActiveSupport::Reloader.to_prepare do

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/inline_svg.rb
+++ b/config/initializers/inline_svg.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 InlineSvg.configure do |config|
   config.asset_finder = InlineSvg::WebpackAssetFinder
 end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rack::Attack.throttle("code execution requests by ip", limit: 5, period: 30) do |req|
   if req.path == '/run' && req.post?
     req.ip

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/preload.rb
+++ b/config/preload.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 require_relative "environment"
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: "home#index"

--- a/lib/ruby_documentation_importer.rb
+++ b/lib/ruby_documentation_importer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rdoc"
 require_relative "rubyapi_rdoc_generator"
 

--- a/lib/ruby_downloader.rb
+++ b/lib/ruby_downloader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RubyDownloader
   RUBY_HOST = "https://cache.ruby-lang.org/pub/ruby/%{base}/ruby-%{version}.tar.gz".freeze
   RUBY_MASTER_URL = "https://codeload.github.com/ruby/ruby/zip/master"

--- a/lib/ruby_downloader.rb
+++ b/lib/ruby_downloader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RubyDownloader
-  RUBY_HOST = "https://cache.ruby-lang.org/pub/ruby/%{base}/ruby-%{version}.tar.gz".freeze
+  RUBY_HOST = "https://cache.ruby-lang.org/pub/ruby/%{base}/ruby-%{version}.tar.gz"
   RUBY_MASTER_URL = "https://codeload.github.com/ruby/ruby/zip/master"
 
   attr_reader :version

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RubyAPIRDocGenerator
   SKIP_NAMESPACES = [
     /Bundler\:\:.*/,

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :assets do
   task :clean do
     # intentionally empty

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../ruby_downloader"
 require_relative "../ruby_documentation_importer"
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class HomeControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/objects_controller_test.rb
+++ b/test/controllers/objects_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class ObjectsControllerTest < ActionDispatch::IntegrationTest

--- a/test/controllers/search_controller_test.rb
+++ b/test/controllers/search_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SearchControllerTest < ActionDispatch::IntegrationTest

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationHelperTest < ActionView::TestCase
   test "github_url" do
     method = ruby_object(String).ruby_methods.first

--- a/test/integration/search_flow_test.rb
+++ b/test/integration/search_flow_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SearchFlowTest < ActionDispatch::IntegrationTest

--- a/test/models/ruby_method_test.rb
+++ b/test/models/ruby_method_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RubyMethodTest < ActiveSupport::TestCase

--- a/test/models/ruby_object_test.rb
+++ b/test/models/ruby_object_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RubyObjectTest < ActiveSupport::TestCase

--- a/test/models/ruby_version_test.rb
+++ b/test/models/ruby_version_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class RubyVersionTest < ActiveSupport::TestCase

--- a/test/services/search/query_test.rb
+++ b/test/services/search/query_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Search::QueryTest < ActiveSupport::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"


### PR DESCRIPTION
Issue #191 points out that objects#show does _a lot_ of allocations. This PR removes about 32.5k allocations from the the String class page for Ruby 2.7 (https://rubyapi.org/2.7/o/string).

(Note: I did each optimization as a commit. The PR might be easier to review by stepping through he commits.)

# Optimization 1

## Avoid deeply nested hash and array allocations

deep_symbolize_keys returns new objects the entire way through the document tree. Additionally, the HashWithIndifferentAccess.new was an extra allocation per RubyObject and RubyMethod.

The Ruby 2.7 String class has 146 methods, which means 147 allocations just in HashWithIndifferentAccess calls.

Before:
Completed 200 OK in 72ms (Views: 57.9ms | Allocations: 58876)

After:
Completed 200 OK in 51ms (Views: 38.7ms | Allocations: 47559)

Removes ~11,000 allocations

# Optimization 2
## Add frozen_string_literal comment to all applicable files

The magic_frozen_string_literal gem made it very easy to add the "magic comment" to all Ruby files.

Before:
Completed 200 OK in 51ms (Views: 38.7ms | Allocations: 47559)

After:
Completed 200 OK in 54ms (Views: 40.2ms | Allocations: 44923)

Removes ~2,600 allocations

# Optimization 3
## Avoid `url_for` for anchor links
Rails' `url_for` method (which object_path uses) is overkill for simply creating a link to an anchor on the current page.

Each call to `object_path` allocates a Hash, and then the Rails `url_for` logic performs a lot more allocations and router lookups, just to inevitably give us `/2.7/o/string#method-i-chr` for the `/2.7/o/string` page. For an anchor, the `/2.7/o/string` is actually irrelevant. `#method-i-chr` as the href will work just fine.

Additionally, the method names are CGI escaped. A single page will escape the same method name 2-4 times, (depending on if there's both an instance and class variable with the same name). We can remove great deal of allocations by caching the escaped name for the duration of the request.

Before:
Completed 200 OK in 54ms (Views: 40.2ms | Allocations: 44923)

After:
Completed 200 OK in 38ms (Views: 24.8ms | Allocations: 26282)

Removes ~19,000 allocations

# Summary
Before:
Completed 200 OK in 72ms (Views: 57.9ms | Allocations: 58876)

After:
Completed 200 OK in 38ms (Views: 24.8ms | Allocations: 26282)

Removes ~32,600 allocations and 30ms