### PR TITLE
Cache escaped method names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :preload, :default do
   gem "meta-tags"
   gem "sentry-raven"
   gem "rack-attack"
+  gem "concurrent-ruby"
 end
 
 gem "slim"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
+  concurrent-ruby
   dotenv-rails
   elasticsearch-persistence
   falcon


### PR DESCRIPTION
Cache escaped method names

Every time objects#show is loaded, all of the class and instance
methods are escaped to be used as an anchor link to the method
on the current page.

The thing is, the value a single method name escapes to is constant,
so there's no ned to calculate it every request. Furthermore,
there's a lot of overlap between classes on method names
(how many classes have a `new` method, for example?).

By storing a cache of the html anchors for a method, we can reduce
a significant amount of allocations on the objects#show page.

Additionally, since these are just links to the same page, we can
actually write a manual <a> tag instead of using link_to.

For `/2.7/o/string`, this removes about 7,000 allocations.

Before:
Completed 200 OK in 51ms (Views: 38.9ms | Allocations: 26304)

After:
Completed 200 OK in 39ms (Views: 25.9ms | Allocations: 24993)

Removes ~1,300 allocations

_Note: This cache is shared between threads._