### PR TITLE
Disable CSRF tokens, site-wide

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class GraphqlController < ApplicationController
-  skip_before_action :verify_authenticity_token
-
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,6 +31,10 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Site doesn't have a login, so the CSRF protection isn't helpful
+  # In fact, it's problematic because the varying CSRF tokens means you can't get a consistent ETag
+  config.action_controller.allow_forgery_protection = false
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,6 +60,10 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
+  # Site doesn't have a login, so the CSRF protection isn't helpful
+  # In fact, it's problematic because the varying CSRF tokens means you can't get a consistent ETag
+  config.action_controller.allow_forgery_protection = false
+
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 


### PR DESCRIPTION
RE: #354

This site doesn't have a login, so there's nothing to protect.

Also, the random string of the CSRF token in the HTML causes the ETag to never be consistent, since the HTML is ever-changing, which makes the page impossible to cache.