### PR TITLE
Importer performance improvement

### DIFF
--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -7,6 +7,8 @@ class RubyAPIRDocGenerator
     /IRB\:\:.*/
   ].freeze
 
+  SKIP_NAMESPACE_REGEX = Regexp.union(SKIP_NAMESPACES).freeze
+
   def class_dir
   end
 
@@ -97,15 +99,11 @@ class RubyAPIRDocGenerator
   end
 
   def skip_namespace?(constant)
-    !skip_namespace_regex.match(constant).nil?
+    SKIP_NAMESPACE_REGEX.match?(constant)
   end
 
   def constant_depth(constant)
     constant.split("::").size
-  end
-
-  def skip_namespace_regex
-    Regexp.union(SKIP_NAMESPACES)
   end
 
   def clean_description(description)


### PR DESCRIPTION
The `skip_namespace_regex` is constant, so we can save a ton of allocations by making it a constant, instead of building it every time we call `skip_namespace?`, which happens once for every single class and module.

Additionally, `match` creates a MatchData object and creates backrefs (the $~, for example). Since we only care whether it does or doesn't match, we can use the `match?` method, which returns a boolean and doesn't create backrefs.