### PR TITLE
Cache the entire ObjectsController#show page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :preload, :default do
 
   gem "elasticsearch-persistence"
 
+  gem "actionpack-action_caching"
   gem "http"
   gem "typhoeus"
   gem "kaminari", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,8 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionpack-action_caching (1.2.1)
+      actionpack (>= 4.0.0)
     actiontext (6.0.2.2)
       actionpack (= 6.0.2.2)
       activerecord (= 6.0.2.2)
@@ -373,6 +375,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   byebug

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -5,6 +5,13 @@ class ObjectsController < ApplicationController
 
   before_action :enable_public_cache
 
+  caches_action :show,
+    expires_in: 30.minutes,
+    # Setting the cache path, because I had troubles getting the separate Ruby versions to
+    # have their own caches. Calling `url_for` for /2.7/o/string simply returns /o/string, and
+    # `url_for` is the default cache path.
+    cache_path: -> { "/#{params[:version]}/o/#{params[:object]}" }
+
   def show
     @object = object_repository.find(document_id)
   end


### PR DESCRIPTION
Avoid even querying Elasticsearch, and just cache the entire HTML string
into Redis.

Before:
Started GET "/2.7/o/string" for 127.0.0.1 at 2020-04-03 01:38:46 -0500
Processing by ObjectsController#show as HTML
  Parameters: {"version"=>"2.7", "object"=>"string"}
ETHON: performed EASY effective_url=http://localhost:9200/ruby_objects_2.7_development/doc/c3RyaW5n response_code=200 return_code=ok total_time=0.007249
  Rendering layouts/application.html.slim
  Rendering objects/show.html.slim within layouts/application
  Rendered objects/show.html.slim within layouts/application (Duration: 2.5ms | Allocations: 3820)
  Rendered layouts/_header.html.slim (Duration: 7.0ms | Allocations: 3454)
  Rendered layouts/application.html.slim (Duration: 12.3ms | Allocations: 8813)
Completed 200 OK in 24ms (Views: 12.7ms | Allocations: 13354)

After:
Started GET "/2.7/o/string" for 127.0.0.1 at 2020-04-03 01:36:17 -0500
Processing by ObjectsController#show as HTML
  Parameters: {"version"=>"2.7", "object"=>"string"}
Completed 200 OK in 1ms (Allocations: 156)