### PR TITLE
Refactor Ruby-src download

### DIFF
--- a/app/models/ruby_version.rb
+++ b/app/models/ruby_version.rb
@@ -5,23 +5,22 @@ class RubyVersion
   def initialize(version, sha512: nil, url: nil)
     if version == "master"
       @version = "master"
-      return
+    else
+      raise ArgumentError unless Gem::Version.correct?(version)
+      @version = Gem::Version.new(version)
     end
 
-    raise ArgumentError unless Gem::Version.correct?(version)
-
-    @version = Gem::Version.new(version)
     @sha512 = sha512
-    @url = url
+    @url = URI(url)
   end
 
-  def minor_release
+  def minor_version
     return "master" if master?
     version.segments[0..1].join(".")
   end
 
   def prerelease?
-    return false if master?
+    return true if master?
     version.prerelease?
   end
 

--- a/app/models/ruby_version.rb
+++ b/app/models/ruby_version.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class RubyVersion
-  attr_accessor :version, :sha512, :url
-  def initialize(version, sha512: nil, url: nil)
+  attr_accessor :version, :sha512, :source_url
+  def initialize(version, sha512: nil, source_url: nil)
     if version == "master"
       @version = "master"
     else
@@ -11,7 +11,7 @@ class RubyVersion
     end
 
     @sha512 = sha512
-    @url = URI(url)
+    @source_url = URI(source_url) if source_url.present?
   end
 
   def minor_version

--- a/app/services/ruby_releases/release_list.rb
+++ b/app/services/ruby_releases/release_list.rb
@@ -5,7 +5,8 @@ require "csv"
 module RubyReleases
   class ReleaseList
     RELEASE_INDEX_URL = "https://cache.ruby-lang.org/pub/ruby/index.txt"
-    SUPPORTED_RELEASE_FORMAT = %w[tar.gz]
+    RUBY_MASTER_ZIP_URL = "https://codeload.github.com/ruby/ruby/zip/master"
+    SUPPORTED_RELEASE_FORMAT = "zip"
 
     def self.fetch
       new.releases
@@ -13,7 +14,7 @@ module RubyReleases
 
     attr_accessor :releases
     def initialize
-      @releases = parse_index(release_index)
+      @releases = parse_index(release_index).push(master)
     end
 
     private
@@ -37,8 +38,12 @@ module RubyReleases
       releases
     end
 
+    def master
+      RubyVersion.new("master", sha512: "", url: RUBY_MASTER_ZIP_URL)
+    end
+
     def supported_release_format?(url)
-      SUPPORTED_RELEASE_FORMAT.any? { |format| url.end_with?(format) }
+      url.end_with?(SUPPORTED_RELEASE_FORMAT)
     end
 
     def release_index

--- a/app/services/ruby_releases/release_list.rb
+++ b/app/services/ruby_releases/release_list.rb
@@ -31,7 +31,7 @@ module RubyReleases
           end
         end
 
-        releases << RubyVersion.new(version, sha512: l["sha512"], url: l["url"]) if supported_release_format?(l["url"])
+        releases << RubyVersion.new(version, sha512: l["sha512"], source_url: l["url"]) if supported_release_format?(l["url"])
       rescue ArgumentError
       end
 
@@ -39,7 +39,7 @@ module RubyReleases
     end
 
     def master
-      RubyVersion.new("master", sha512: "", url: RUBY_MASTER_ZIP_URL)
+      RubyVersion.new("master", sha512: "", source_url: RUBY_MASTER_ZIP_URL)
     end
 
     def supported_release_format?(url)

--- a/lib/ruby_documentation_importer.rb
+++ b/lib/ruby_documentation_importer.rb
@@ -4,23 +4,22 @@ require "rdoc"
 require_relative "rubyapi_rdoc_generator"
 
 class RubyDocumentationImporter
-  attr_reader :version, :path
+  attr_reader :release
 
-  def self.import(version, path)
-    importer = new(version, path)
-    importer.import
-    importer
+  def self.import(release)
+    new(release).import
   end
 
-  def initialize(version, path)
-    @version = version
-    @path = path
+  def initialize(release)
+    @release = release
     @rdoc = RDoc::RDoc.new
     @rdoc_options = @rdoc.load_options
-    @spinner = TTY::Spinner.new ":spinner Importing Ruby #{version} documentation"
+    @spinner = TTY::Spinner.new ":spinner Importing Ruby #{release.version} documentation"
   end
 
   def import
+    path = fetch_ruby_src_for_release(release).extracted_download_path
+
     @spinner.auto_spin
 
     @rdoc_options.tap do |r|
@@ -29,11 +28,18 @@ class RubyDocumentationImporter
       r.template = ""
       r.quiet = true
       r.op_dir = Rails.root.join("tmp", "rdoc")
-      r.generator_options = [version]
+      r.generator_options = [release]
     end
 
     @rdoc.document @rdoc_options
+
     @spinner.stop
     puts "Done."
+  end
+
+  private
+
+  def fetch_ruby_src_for_release(release)
+    RubyDownloader.download(release)
   end
 end

--- a/lib/ruby_downloader.rb
+++ b/lib/ruby_downloader.rb
@@ -29,14 +29,14 @@ class RubyDownloader
   end
 
   def download_path
-    rubies_download_path.join File.basename(release.url.path)
+    rubies_download_path.join File.basename(release.source_url.path)
   end
 
   def extracted_download_path
     if release.master?
       rubies_download_path.join "ruby-master"
     else
-      rubies_download_path.join File.basename(release.url.path, ".zip")
+      rubies_download_path.join File.basename(release.source_url.path, ".zip")
     end
   end
 
@@ -44,7 +44,7 @@ class RubyDownloader
 
   def fetch_ruby_archive
     file = File.new download_path, "wb"
-    request = HTTP.get release.url.to_s
+    request = HTTP.get release.source_url.to_s
 
     while (chunk = request.readpartial)
       file.write chunk

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -18,8 +18,8 @@ class RubyAPIRDocGenerator
   def initialize(store, options)
     @store = store
     @options = options
-    @full_version = options.generator_options.pop
-    @version = @full_version == "master" ? "master" : Gem::Version.new(@full_version).segments[0..1].join(".")
+    @release = options.generator_options.pop
+    @version = @release.minor_version
     @documentation = store.all_classes_and_modules
   end
 
@@ -46,7 +46,7 @@ class RubyAPIRDocGenerator
           description: clean_description(method_doc.description),
           object_constant: doc.full_name,
           method_type: "#{method_doc.type}_method",
-          source_location: "#{@full_version}:#{method_path(method_doc)}:#{method_doc.line}",
+          source_location: "#{@release.version}:#{method_path(method_doc)}:#{method_doc.line}",
           call_sequence: method_doc.call_seq ? method_doc.call_seq.strip.split("\n").map { |s| s.gsub "->", "→" } : "",
           metadata: {
             depth: constant_depth(doc.full_name)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -8,24 +8,23 @@ namespace :import do
   task :ruby, [:version] => :environment do |t, args|
     args.with_defaults version: Rails.configuration.default_ruby_version
 
-    downloader = RubyDownloader.download(args.version)
-    RubyDocumentationImporter.import(args.version, downloader.extracted_download_path)
+    release = RubyReleases::ReleaseList.fetch.find { |r| r.version.to_s == args.version }
+
+    unless release
+      puts "Could not find MRI release for version #{args.version}"
+      exit 1
+    end
+
+    RubyDocumentationImporter.import release
   end
 
   namespace :ruby do
     task all: :environment do
-      ruby_versions = Hash.new { |h, k| h[k] = [] }
+      releases = RubyReleases::ReleaseList.fetch
 
-      RubyReleases::ReleaseList.fetch.each do |r|
-        minor_version = r.version.segments[0..1].join(".")
-        ruby_versions[minor_version] << r.version.to_s
-      end
-
-      versions = Rails.configuration.ruby_versions.map { |v| ruby_versions[v].max }.compact
-
-      versions.each do |v|
-        downloader = RubyDownloader.download(v)
-        RubyDocumentationImporter.import(v, downloader.extracted_download_path)
+      Rails.configuration.ruby_versions.each do |v|
+        release = releases.select { |r| r.minor_version == v }.max_by(&:version)
+        RubyDocumentationImporter.import release
       end
     end
   end

--- a/test/models/ruby_version_test.rb
+++ b/test/models/ruby_version_test.rb
@@ -9,9 +9,9 @@ class RubyVersionTest < ActiveSupport::TestCase
     end
   end
 
-  test "#minor_release" do
+  test "#minor_version" do
     version = RubyVersion.new("2.4.0")
-    assert_equal version.minor_release, "2.4"
+    assert_equal version.minor_version, "2.4"
   end
 
   test "#prerelease?" do

--- a/test/services/ruby_releases/release_list_test.rb
+++ b/test/services/ruby_releases/release_list_test.rb
@@ -43,6 +43,6 @@ class RubyReleases::RubyReleasesListTest < ActiveSupport::TestCase
 
   test "fetching ruby releases" do
     releases = RubyReleases::ReleaseList.fetch
-    assert_equal releases.size, 6
+    assert_equal releases.size, 7 # Note: a release for 'master' is automatically added
   end
 end


### PR DESCRIPTION
This PR refactors/cleans up the part of the Documentation importer that downloads the ruby source code. I'll admit this PR is a bit messy but the gist of it is:

* Instead of passing a version string around, we instead build a `RubyVersion` and pass that around to download the ruby-src.
* Instead of downloading `.tar.gz` files for releases, and `.zip` files for `master`, we instead only just download the `.zip` for everything.
* Fixes #301