### PR TITLE
DRY the header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,7 +9,10 @@ module ApplicationHelper
   end
 
   def homepage?
-    current_page?(root_path) || current_page?(versioned_root_path(version: ruby_version))
+    return(@is_homepage) if defined?(@is_homepage)
+    @is_homepage = begin
+      current_page?(root_path) || current_page?(versioned_root_path(version: ruby_version))
+    end
   end
 
   # Map a method source file into a url to Github.com

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -18,13 +18,8 @@ div class="bg-red-600 dark:bg-gray-700 text-white md:pb-6"
 
   div class="flex flex-col justify-center items-center p-6 md:pt-6 pt-0 text-center"
       h2 class="md:text-3xl text-2xl font-semibold my-3" Search and Explore Ruby Documentation
-      div class="relative xxl:w-4/12 md:w-6/12 w-full" data-controller="search" data-search-version="#{ruby_version}" data-search-url="#{graphql_path}"
-        = form_tag search_url(version: ruby_version), method: :get, id: "search" do
-          div class="relative"
-            button type="submit" class="absolute left inset-y-0 px-4 text-gray-700 fill-current"
-              span data-target="search.button" class="fa fa-search"
-            input id="search" class="bg-white shadow-md rounded pl-10 px-3 py-3 w-full outline-none z-0 text-gray-800 placeholder-gray-600 placeholder-opacity-100" data-target="search.input" data-action="keyup->search#autocomplete"  name="q" type="text" autocapitalize="off" autocorrect="off" autocomplete="off" placeholder="Search Ruby Documentation" aria-label="Search" title="Search" autofocus="yes"
-            div data-target="search.autocomplete" class="w-full bg-white absolute shadow-lg rounded-bl rounded-br -mt-1 text-left"
+      div class="xxl:w-4/12 md:w-6/12 w-full"
+        = render 'layouts/search_form'
 div class="p-6 max-w-screen-xl mx-auto"
   div class="flex flex-wrap"
     div class="block w-full md:w-6/12 md:p-3 py-3"

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -13,42 +13,9 @@
           }
         }
 
-div class="bg-red-600 dark:bg-gray-700 text-white md:pt-3 md:pb-6"
-  header id="header" class="text-white flex items-center h-16"
-    nav class="w-full max-w-screen-xl mx-auto" role="navigation" aria-label="main navigation"
-      div class="flex items-center justify-between px-6"
-        div class="lg:w-2/12 w-2/12"
-          = link_to root_path, class: "block" do
-            = inline_svg_pack_tag "media/packs/app/logo-plain.svg", class: "md:hidden w-10 h-10"
-            = inline_svg_pack_tag "media/packs/app/logo.svg", class: "hidden md:block w-48"
-        div class="md:w-2/12 w-6/12"
-          div class="flex flex-row-reverse"
-            div class="block relative ml-4" data-controller="github-links"
-              button class="relative z-20 text-xl hover:text-red-100 dark:hover:text-gray-400" data-action="click->github-links#toggle"
-                i class="fab fa-github hover:fill-current"
-              button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="github-links.linksOverlay" tabindex="-1" data-action="click->github-links#out"
-              div class="dropdown absolute z-50 w-64 text-gray-700 bg-white dark:bg-gray-900 dark:text-gray-400 shadow-xl rounded py-2 right-0 invisible p-2 z-50" data-target="github-links.linksList"
-                a class="block p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800" href="https://github.com/ruby/ruby" target="_blank" rel="noopener"
-                    div class="text-gray-800 dark:text-gray-200 fill-current"
-                      i class="fab fa-github inline-block mr-2"
-                      h1 class="inline text-lg font-semibold" ruby/ruby
-                    p class="text-xs py-1" Ruby is an interpreted object-oriented programming language often used for web development. It also offers many scripting features to process plain text and serialized files, or manage system tasks. It is simple, straightforward, and extensible.
-                hr class="my-2"
-                a class="block p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800" href="https://github.com/rubyapi/rubyapi" target="_blank" rel="noopener"
-                    div class="text-gray-800 dark:text-gray-200 fill-current"
-                      i class="fab fa-github inline-block mr-2"
-                      h1 class="inline text-lg font-semibold" rubyapi/rubyapi
-                    p class="text-xs py-1" Ruby API is a Ruby on Rails app that makes browsing and searching Ruby's documentation easy and fast for users.
+div class="bg-red-600 dark:bg-gray-700 text-white md:pb-6"
+  = render 'layouts/header'
 
-            div class="relative" data-controller="ruby-version"
-              button class="relative z-20 text-xl pl-2 hover:text-red-100 dark:hover:text-gray-400 hover:fill-current" data-action="click->ruby-version#toggle"
-                | #{ruby_version}
-                i class="ml-2 fas fa-caret-down"
-              button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="ruby-version.versionOverlay" tabindex="-1" data-action="click->ruby-version#out"
-              div class="dropdown absolute w-32 bg-white text-gray-700 dark:bg-gray-900 dark:text-gray-400 shadow-xl rounded py-2 right-0 invisible z-50" data-target="ruby-version.versionList"
-                - available_ruby_versions.each do |version|
-                  a class="block px-4 py-1 text-l hover:bg-gray-200 dark:hover:bg-gray-800" href="#{route_for_version version}"
-                    | #{version}
   div class="flex flex-col justify-center items-center p-6 md:pt-6 pt-0 text-center"
       h2 class="md:text-3xl text-2xl font-semibold my-3" Search and Explore Ruby Documentation
       div class="relative xxl:w-4/12 md:w-6/12 w-full" data-controller="search" data-search-version="#{ruby_version}" data-search-url="#{graphql_path}"

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -13,7 +13,7 @@
           }
         }
 
-div class="bg-red-600 dark:bg-gray-700 text-white md:pb-6"
+div class="bg-red-600 dark:bg-gray-700 text-white md:pt-3 md:pb-6"
   = render 'layouts/header'
 
   div class="flex flex-col justify-center items-center p-6 md:pt-6 pt-0 text-center"

--- a/app/views/layouts/_github_links.html.slim
+++ b/app/views/layouts/_github_links.html.slim
@@ -1,0 +1,17 @@
+-# frozen_string_literal: true
+div class="#{homepage? ? 'block' : 'hidden md:block'} relative ml-4" data-controller="github-links"
+  button class="relative z-20 text-xl hover:text-red-100 dark:hover:text-gray-400" data-action="click->github-links#toggle"
+    i class="fab fa-github hover:fill-current"
+  button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="github-links.linksOverlay" tabindex="-1" data-action="click->github-links#out"
+  div class="dropdown absolute z-50 w-64 text-gray-700 bg-white dark:bg-gray-900 dark:text-gray-400 shadow-xl rounded py-2 right-0 invisible p-2 z-50" data-target="github-links.linksList"
+    a class="block p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800" href="https://github.com/ruby/ruby" target="_blank" rel="noopener"
+        div class="text-gray-800 dark:text-gray-200 fill-current"
+          i class="fab fa-github inline-block mr-2"
+          h1 class="inline text-lg font-semibold" ruby/ruby
+        p class="text-xs py-1" Ruby is an interpreted object-oriented programming language often used for web development. It also offers many scripting features to process plain text and serialized files, or manage system tasks. It is simple, straightforward, and extensible.
+    hr class="my-2"
+    a class="block p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800" href="https://github.com/rubyapi/rubyapi" target="_blank" rel="noopener"
+        div class="text-gray-800 dark:text-gray-200 fill-current"
+          i class="fab fa-github inline-block mr-2"
+          h1 class="inline text-lg font-semibold" rubyapi/rubyapi
+        p class="text-xs py-1" Ruby API is a Ruby on Rails app that makes browsing and searching Ruby's documentation easy and fast for users.

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -3,42 +3,10 @@ header id="header" class="flex items-center inset-x-0 z-50 h-16#{' text-white bg
   nav class="w-full max-w-screen-xl mx-auto" role="navigation" aria-label="main navigation"
     div class="flex items-center justify-between px-3"
       div class="lg:w-2/12 w-2/12"
-        = link_to root_path, class: "block" do
-          = inline_svg_pack_tag "media/packs/app/logo-plain.svg", class: "md:hidden w-10 h-10"
-          = inline_svg_pack_tag "media/packs/app/logo.svg", class: "hidden md:block w-48"
+        = render 'layouts/logo'
       div class="lg:w-5/12 md:w-6/12 w-8/12"
-        div class="relative" data-controller="search" data-search-version="#{ruby_version}" data-search-url="#{graphql_path}"
-          - unless homepage?
-            = form_tag search_url(version: ruby_version), method: :get do
-              button type="submit" class="absolute left inset-y-0 px-4" aria-label="search"
-                span data-target="search.button" class="fa fa-search"
-              input id="search" name="q" data-target="search.input" data-action="keyup->search#autocomplete" class="bg-red-800 dark:bg-gray-800 rounded px-3 pl-10 py-2 w-full outline-none placeholder-white placeholder-opacity-100 focus:bg-white focus:text-black" value="#{search_query}" type="text" autocapitalize="off" autocorrect="off" autocomplete="off" placeholder="Search Ruby Documentation" aria-label="Search" title="Search"
-              div data-target="search.autocomplete" class="w-full bg-white absolute shadow-lg rounded-bl rounded-br -mt-1"
+        = render 'layouts/search_form' unless homepage?
       div class="#{homepage? ? 'md:w-2/12 w-6/12' : 'w-2/12'}"
         div class="flex flex-row-reverse"
-          div class="#{homepage? ? 'block' : 'hidden md:block'} relative ml-4" data-controller="github-links"
-            button class="relative z-20 text-xl hover:text-red-100 dark:hover:text-gray-400" data-action="click->github-links#toggle"
-              i class="fab fa-github hover:fill-current"
-            button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="github-links.linksOverlay" tabindex="-1" data-action="click->github-links#out"
-            div class="dropdown absolute z-50 w-64 text-gray-700 bg-white dark:bg-gray-900 dark:text-gray-400 shadow-xl rounded py-2 right-0 invisible p-2 z-50" data-target="github-links.linksList"
-              a class="block p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800" href="https://github.com/ruby/ruby" target="_blank" rel="noopener"
-                  div class="text-gray-800 dark:text-gray-200 fill-current"
-                    i class="fab fa-github inline-block mr-2"
-                    h1 class="inline text-lg font-semibold" ruby/ruby
-                  p class="text-xs py-1" Ruby is an interpreted object-oriented programming language often used for web development. It also offers many scripting features to process plain text and serialized files, or manage system tasks. It is simple, straightforward, and extensible.
-              hr class="my-2"
-              a class="block p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800" href="https://github.com/rubyapi/rubyapi" target="_blank" rel="noopener"
-                  div class="text-gray-800 dark:text-gray-200 fill-current"
-                    i class="fab fa-github inline-block mr-2"
-                    h1 class="inline text-lg font-semibold" rubyapi/rubyapi
-                  p class="text-xs py-1" Ruby API is a Ruby on Rails app that makes browsing and searching Ruby's documentation easy and fast for users.
-
-          div class="relative" data-controller="ruby-version"
-            button class="relative z-20 #{homepage? ? 'text-xl' : 'md:text-xl text-l'} pl-2 hover:text-red-100 dark:hover:text-gray-400 hover:fill-current" data-action="click->ruby-version#toggle" aria-label="Show github links"
-              | #{ruby_version}
-              i class="ml-2 fas fa-caret-down"
-            button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="ruby-version.versionOverlay" tabindex="-1" data-action="click->ruby-version#out"
-            div class="dropdown absolute w-32 bg-white text-gray-700 dark:bg-gray-900 dark:text-gray-400 shadow-xl rounded py-2 right-0 invisible z-50" data-target="ruby-version.versionList"
-              - available_ruby_versions.each do |version|
-                a class="block px-4 py-1 text-l hover:bg-gray-200 dark:hover:bg-gray-800" href="#{route_for_version version}"
-                  | #{version}
+          = render 'layouts/github_links'
+          = render 'layouts/version_selector'

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,7 +1,7 @@
 -# frozen_string_literal: true
 header id="header" class="flex items-center inset-x-0 z-50 h-16#{' text-white bg-red-600 dark:bg-gray-700 fixed top-0' unless homepage?}"
   nav class="w-full max-w-screen-xl mx-auto" role="navigation" aria-label="main navigation"
-    div class="flex items-center justify-between px-3"
+    div class="flex items-center justify-between #{homepage? ? 'px-6' : 'px-3'}"
       div class="lg:w-2/12 w-2/12"
         = render 'layouts/logo'
       div class="lg:w-5/12 md:w-6/12 w-8/12"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,5 +1,5 @@
 -# frozen_string_literal: true
-header id="header" class="text-white bg-red-600 dark:bg-gray-700 flex items-center fixed top-0 inset-x-0 z-50 h-16"
+header id="header" class="flex items-center inset-x-0 z-50 h-16#{' text-white bg-red-600 dark:bg-gray-700 fixed top-0' unless homepage?}"
   nav class="w-full max-w-screen-xl mx-auto" role="navigation" aria-label="main navigation"
     div class="flex items-center justify-between px-3"
       div class="lg:w-2/12 w-2/12"
@@ -8,14 +8,15 @@ header id="header" class="text-white bg-red-600 dark:bg-gray-700 flex items-cent
           = inline_svg_pack_tag "media/packs/app/logo.svg", class: "hidden md:block w-48"
       div class="lg:w-5/12 md:w-6/12 w-8/12"
         div class="relative" data-controller="search" data-search-version="#{ruby_version}" data-search-url="#{graphql_path}"
-          = form_tag search_url(version: ruby_version), method: :get do
-            button type="submit" class="absolute left inset-y-0 px-4" aria-label="search"
-              span data-target="search.button" class="fa fa-search"
-            input id="search" name="q" data-target="search.input" data-action="keyup->search#autocomplete" class="bg-red-800 dark:bg-gray-800 rounded px-3 pl-10 py-2 w-full outline-none placeholder-white placeholder-opacity-100 focus:bg-white focus:text-black" value="#{search_query}" type="text" autocapitalize="off" autocorrect="off" autocomplete="off" placeholder="Search Ruby Documentation" aria-label="Search" title="Search"
-            div data-target="search.autocomplete" class="w-full bg-white absolute shadow-lg rounded-bl rounded-br -mt-1"
-      div class="w-2/12"
+          - unless homepage?
+            = form_tag search_url(version: ruby_version), method: :get do
+              button type="submit" class="absolute left inset-y-0 px-4" aria-label="search"
+                span data-target="search.button" class="fa fa-search"
+              input id="search" name="q" data-target="search.input" data-action="keyup->search#autocomplete" class="bg-red-800 dark:bg-gray-800 rounded px-3 pl-10 py-2 w-full outline-none placeholder-white placeholder-opacity-100 focus:bg-white focus:text-black" value="#{search_query}" type="text" autocapitalize="off" autocorrect="off" autocomplete="off" placeholder="Search Ruby Documentation" aria-label="Search" title="Search"
+              div data-target="search.autocomplete" class="w-full bg-white absolute shadow-lg rounded-bl rounded-br -mt-1"
+      div class="#{homepage? ? 'md:w-2/12 w-6/12' : 'w-2/12'}"
         div class="flex flex-row-reverse"
-          div class="hidden md:block relative ml-4" data-controller="github-links"
+          div class="#{homepage? ? 'block' : 'hidden md:block'} relative ml-4" data-controller="github-links"
             button class="relative z-20 text-xl hover:text-red-100 dark:hover:text-gray-400" data-action="click->github-links#toggle"
               i class="fab fa-github hover:fill-current"
             button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="github-links.linksOverlay" tabindex="-1" data-action="click->github-links#out"
@@ -33,7 +34,7 @@ header id="header" class="text-white bg-red-600 dark:bg-gray-700 flex items-cent
                   p class="text-xs py-1" Ruby API is a Ruby on Rails app that makes browsing and searching Ruby's documentation easy and fast for users.
 
           div class="relative" data-controller="ruby-version"
-            button class="relative z-20 md:text-xl text-l pl-2 hover:text-red-100 dark:hover:text-gray-400 hover:fill-current" data-action="click->ruby-version#toggle" aria-label="Show github links"
+            button class="relative z-20 #{homepage? ? 'text-xl' : 'md:text-xl text-l'} pl-2 hover:text-red-100 dark:hover:text-gray-400 hover:fill-current" data-action="click->ruby-version#toggle" aria-label="Show github links"
               | #{ruby_version}
               i class="ml-2 fas fa-caret-down"
             button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="ruby-version.versionOverlay" tabindex="-1" data-action="click->ruby-version#out"

--- a/app/views/layouts/_logo.html.slim
+++ b/app/views/layouts/_logo.html.slim
@@ -1,0 +1,4 @@
+-# frozen_string_literal: true
+= link_to root_path, class: "block" do
+  = inline_svg_pack_tag "media/packs/app/logo-plain.svg", class: "md:hidden w-10 h-10"
+  = inline_svg_pack_tag "media/packs/app/logo.svg", class: "hidden md:block w-48"

--- a/app/views/layouts/_search_form.html.slim
+++ b/app/views/layouts/_search_form.html.slim
@@ -1,0 +1,8 @@
+-# frozen_string_literal: true
+div class="relative" data-controller="search" data-search-version="#{ruby_version}" data-search-url="#{graphql_path}"
+  = form_tag search_url(version: ruby_version), method: :get do
+    div class="relative"
+      button type="submit" class="absolute left inset-y-0 px-4 #{'text-gray-700 fill-current' if homepage?}" aria-label="search"
+        span data-target="search.button" class="fa fa-search"
+      input id="search" name="q" data-target="search.input" data-action="keyup->search#autocomplete" type="text" autocapitalize="off" autocorrect="off" autocomplete="off" placeholder="Search Ruby Documentation" aria-label="Search" title="Search" value=(search_query unless homepage?) class="#{homepage? ? 'bg-white shadow-md py-3 z-0 text-gray-800 placeholder-gray-600' : 'bg-red-800 dark:bg-gray-800 py-2 placeholder-white focus:bg-white focus:text-black'} rounded px-3 pl-10 py-2 w-full outline-none placeholder-opacity-100" *{homepage? ? 'autofocus' : '' => ''}
+      div data-target="search.autocomplete" class="w-full bg-white absolute shadow-lg rounded-bl rounded-br -mt-1 #{'text-left' if homepage?}"

--- a/app/views/layouts/_version_selector.html.slim
+++ b/app/views/layouts/_version_selector.html.slim
@@ -1,0 +1,10 @@
+-# frozen_string_literal: true
+div class="relative" data-controller="ruby-version"
+  button class="relative z-20 #{homepage? ? 'text-xl' : 'md:text-xl text-l'} pl-2 hover:text-red-100 dark:hover:text-gray-400 hover:fill-current" data-action="click->ruby-version#toggle" aria-label="Show github links"
+    | #{ruby_version}
+    i class="ml-2 fas fa-caret-down"
+  button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="ruby-version.versionOverlay" tabindex="-1" data-action="click->ruby-version#out"
+  div class="dropdown absolute w-32 bg-white text-gray-700 dark:bg-gray-900 dark:text-gray-400 shadow-xl rounded py-2 right-0 invisible z-50" data-target="ruby-version.versionList"
+    - available_ruby_versions.each do |version|
+      a class="block px-4 py-1 text-l hover:bg-gray-200 dark:hover:bg-gray-800" href="#{route_for_version version}"
+        | #{version}


### PR DESCRIPTION
The header was copy/pasted between the home page and header layout because of a few intentional differences for the home page:
* doesn't have a fixed top header
* doesn't have a search button in the header
* includes GitHub link

There was one difference that I believe was unintentional, some spacing on the left/right and top/bottom was bigger on the home page than the rest of the site, which made the header jump around as you navigated between pages. I made the home page be the same as the rest of the site. (This is actually what got me to do this.)

There was one difference that I wasn't sure if it was intentional, but I kept it. The version number in the header on mobile is bigger on the home page than the rest of the site. Given that there's no search bar, there's a little more space, so I thought this was intentional and kept it.

# Before
<img width="1792" alt="Screen Shot 2020-04-03 at 11 34 38 PM" src="https://user-images.githubusercontent.com/5104186/78418735-b9f4db00-7604-11ea-933c-999188c84e4e.png">

# After
<img width="1792" alt="Screen Shot 2020-04-03 at 11 34 27 PM" src="https://user-images.githubusercontent.com/5104186/78418738-c1b47f80-7604-11ea-8bf1-7ddd3692f5fb.png">

The rest of the site is visually identical to prod.

Tip for reviewing the diff:
"Hide whitespace changes". There's a pretty big section around the search bar that "changed" but really it's just tabbed in and wrapped in an `if`.