### PR TITLE
Update Gemfile ruby version to match .ruby-version file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "2.7.1"
+ruby "~> 2.7.1"
 
 group :preload, :default do
   gem "rails", "~> 6.0.2"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "~> 2.6"
+ruby "2.7.1"
 
 group :preload, :default do
   gem "rails", "~> 6.0.2"


### PR DESCRIPTION
To be honest, I'm not sure what this is for, but I know CI (and presumably prod) use the .ruby-version file, which says `2.7.1`.