### PR TITLE
Fix safari icon

### DIFF
--- a/app/javascript/packs/app/safari-pinned-tab.svg
+++ b/app/javascript/packs/app/safari-pinned-tab.svg
@@ -1,1 +1,1 @@
-<svg height="100" viewBox="0 0 100 100" width="100" xmlns="http://www.w3.org/2000/svg"><path d="m3.04 5.876 4.96 4.8 4.96-4.8h3.04l-8 7.742-8-7.742z"/><path d="m8.081 8.818-5.01-4.8h10.02z"/></svg>
+<svg height="100" viewBox="0 0 100 100" width="100" xmlns="http://www.w3.org/2000/svg"><path d="m19 35.503 31 30 31-30h19l-50 48.388-50-48.388z"/><path d="m50.506 53.891-31.312-30h62.625z"/></svg>


### PR DESCRIPTION
I apparently had a cache on my computer, because the icon is wrong. Sorry about that. The canvas size was all wrong, so the image was 10px by 10px inside image of a 100px by 100px canvas... This fixes it to be properly sized in the canvas.