### PR TITLE
Make RDoc links be consistent with the rest of the Rails app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ group :preload, :default do
   gem "meta-tags"
   gem "sentry-raven"
   gem "rack-attack"
+  gem "rdoc"
+  gem "trenni-sanitize"
 end
 
 gem "slim"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,9 +284,12 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    rake-compiler (1.1.0)
+      rake
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rdoc (6.2.1)
     redis (4.2.1)
     regexp_parser (1.7.0)
     request_store (1.5.0)
@@ -341,6 +344,10 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timers (4.3.0)
+    trenni (3.9.0)
+      rake-compiler
+    trenni-sanitize (0.5.0)
+      trenni (~> 3.5)
     tty-cursor (0.7.1)
     tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
@@ -401,6 +408,7 @@ DEPENDENCIES
   meta-tags
   rack-attack
   rails (~> 6.0.3)
+  rdoc
   redis (~> 4.2)
   selenium-webdriver
   sentry-raven
@@ -408,6 +416,7 @@ DEPENDENCIES
   skylight
   slim
   standard
+  trenni-sanitize
   tty-spinner
   typhoeus
   web-console (>= 3.3.0)

--- a/lib/ruby_description_cleaner.rb
+++ b/lib/ruby_description_cleaner.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class RubyDescriptionCleaner < Trenni::Sanitize::Filter
+  def self.clean(version, object_constant, description)
+    # Most of this method is copy/pasted from Trenni::Sanitize::Filter.parse
+    # https://github.com/ioquatix/trenni-sanitize/blob/c8e08d2717b98a2268da89f8196fdb1eb93725bf/lib/trenni/sanitize/filter.rb#L40
+
+    description = description.gsub(/(<a.*&para;<\/a>)/, "")
+      .gsub(/(<a.*&uarr;<\/a>)/, "")
+      .gsub("<pre class=\"ruby\">", "<div class=\"ruby\" data-controller=\"code-example\" data-target=\"code-example.block\" data-code-example-version=\"#{@version}\"></div><pre class=\"ruby\">")
+      .gsub(/<a.*?href=""\w+"".*?>(.+?)<\/a>/, "\\1")
+
+    input = Trenni::Buffer(description)
+    output = Trenni::MarkupString.new.force_encoding(input.encoding)
+    entities = Trenni::Entities::HTML5
+
+    delegate = new(output, entities)
+    delegate.version = version
+    delegate.object_constant = object_constant
+
+    delegate.parse!(input)
+
+    delegate.output
+  rescue Trenni::ParseError
+    warn "#{object_constant} contains unparsable HTML"
+    description
+  end
+
+  attr_accessor :version, :object_constant
+
+  def filter(node)
+    if node.name == "a" && (url = node.tag.attributes["href"])
+      uri = URI(url)
+      if uri.host.nil? && uri.path.present?
+        # Only edit relative paths, but skip anchor-only paths.
+        node.tag.attributes["href"] = cleaned_href(uri)
+      end
+    end
+
+    node.accept!
+  rescue URI::InvalidURIError
+    warn "#{object_constant} contains invalid href: #{url}"
+    # Not a valid URL, so get rid of the <a> and just return the content.
+    # EG: '<a href=":ssl">options</a>' becomes 'options'
+    node.skip!(TAG)
+  end
+
+  def cleaned_href(uri)
+    class_parts = object_constant.split("::")[0..-2]
+
+    uri.path.delete_suffix(".html").split("/").each do |path_part|
+      if path_part == ".."
+        class_parts.pop
+      else
+        class_parts.push(path_part)
+      end
+    end
+
+    Rails.application.routes.url_helpers.object_path({
+      version: version,
+      object: class_parts.join("/").downcase,
+      anchor: uri.fragment
+    })
+  end
+end

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "ruby_description_cleaner"
+
 class RubyAPIRDocGenerator
   SKIP_NAMESPACES = [
     /Bundler::.*/,
@@ -43,7 +45,7 @@ class RubyAPIRDocGenerator
 
         methods << {
           name: method_doc.name,
-          description: clean_description(method_doc.description),
+          description: clean_description(doc.full_name, method_doc.description),
           object_constant: doc.full_name,
           method_type: "#{method_doc.type}_method",
           source_location: "#{@release.version}:#{method_path(method_doc)}:#{method_doc.line}",
@@ -65,7 +67,7 @@ class RubyAPIRDocGenerator
 
       objects << RubyObject.new(
         name: doc.name,
-        description: clean_description(doc.description),
+        description: clean_description(doc.full_name, doc.description),
         methods: methods,
         constant: doc.full_name,
         object_type: "#{doc.type}_object",
@@ -117,10 +119,7 @@ class RubyAPIRDocGenerator
     constant.split("::").size
   end
 
-  def clean_description(description)
-    description
-      .gsub(/(<a.*&para;<\/a>)/, "")
-      .gsub(/(<a.*&uarr;<\/a>)/, "")
-      .gsub("<pre class=\"ruby\">", "<div class=\"ruby\" data-controller=\"code-example\" data-target=\"code-example.block\" data-code-example-version=\"#{@version}\"></div><pre class=\"ruby\">")
+  def clean_description(method_class, description)
+    RubyDescriptionCleaner.clean(@version, method_class, description)
   end
 end

--- a/test/lib/ruby_description_cleaner_test.rb
+++ b/test/lib/ruby_description_cleaner_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyDescriptionCleanerTest < ActiveSupport::TestCase
+  test "simple class" do
+    input = <<-HTML
+      <p>Appends the given object to <em>str</em>. If the object is an <a href="Integer.html"><code>Integer</code></a>, it is considered a codepoint and converted to a character before being appended.</p>
+    HTML
+
+    output = <<-HTML
+      <p>Appends the given object to <em>str</em>. If the object is an <a href="/2.4/o/integer"><code>Integer</code></a>, it is considered a codepoint and converted to a character before being appended.</p>
+    HTML
+
+    assert_equal RubyDescriptionCleaner.clean("2.4", "String", input), output
+  end
+
+  test "deep nesting class" do
+    input = <<-HTML
+      <p>An instance of <a href="../../OpenSSL/X509/Certificate.html"><code>OpenSSL::X509::Certificate</code></a>.  If this is not provided, then a generic X509 is generated, with a correspond :SSLPrivateKey</p>
+    HTML
+
+    output = <<-HTML
+      <p>An instance of <a href="/2.3/o/openssl/x509/certificate"><code>OpenSSL::X509::Certificate</code></a>.  If this is not provided, then a generic X509 is generated, with a correspond :SSLPrivateKey</p>
+    HTML
+
+    assert_equal RubyDescriptionCleaner.clean("2.3", "DRb::DRbSSLSocket::SSLConfig", input), output
+  end
+
+  test "invalid URI" do
+    input = <<-HTML
+      <p>If <a href=":ssl">options</a> is true, then an attempt will be made to use SSL (now TLS) to connect to the server.  For this to work <a href="../OpenSSL.html"><code>OpenSSL</code></a> [OSSL] and the Ruby <a href="../OpenSSL.html"><code>OpenSSL</code></a> [RSSL] extensions need to be installed.  If <a href=":ssl">options</a> is a hash, it&#39;s passed to <a href="../OpenSSL/SSL/SSLContext.html#method-i-set_params"><code>OpenSSL::SSL::SSLContext#set_params</code></a> as parameters.</p>
+    HTML
+
+    output = <<-HTML
+      <p>If options is true, then an attempt will be made to use SSL (now TLS) to connect to the server.  For this to work <a href="/2.6/o/openssl"><code>OpenSSL</code></a> [OSSL] and the Ruby <a href="/2.6/o/openssl"><code>OpenSSL</code></a> [RSSL] extensions need to be installed.  If options is a hash, it's passed to <a href="/2.6/o/openssl/ssl/sslcontext#method-i-set_params"><code>OpenSSL::SSL::SSLContext#set_params</code></a> as parameters.</p>
+    HTML
+
+    assert_equal RubyDescriptionCleaner.clean("2.6", "Net::FTP", input), output
+  end
+
+  test "doubled up quotes" do
+    # This is real HTML from RDoc. Note the quotes in <a href=""EXISTS"">.
+    input = <<-HTML
+      <p>After you have selected a mailbox, you may retrieve the number of items in that mailbox from @<a href=""EXISTS"">responses</a>[-1], and the number of recent messages from @<a href=""RECENT"">responses</a>[-1]. Note that these values can change if new messages arrive during a session; see <a href="IMAP.html#method-i-add_response_handler"><code>add_response_handler()</code></a> for a way of detecting this event.</p>
+    HTML
+
+    output = <<-HTML
+      <p>After you have selected a mailbox, you may retrieve the number of items in that mailbox from @responses[-1], and the number of recent messages from @responses[-1]. Note that these values can change if new messages arrive during a session; see <a href="/2.7/o/imap#method-i-add_response_handler"><code>add_response_handler()</code></a> for a way of detecting this event.</p>
+    HTML
+
+    assert_equal RubyDescriptionCleaner.clean("2.7", "IMAP", input), output
+  end
+
+  test "unparsable HTML" do
+    input = <<-HTML
+      <p>s*(((([“‘]).*?<a href=”^/’“>”>5)|</a>*)*?)(/)?&gt;/um, true)</p>
+    HTML
+
+    # This needs to be fixed in RDoc
+    # https://github.com/ruby/rdoc/issues/763
+    output = input
+
+    assert_equal RubyDescriptionCleaner.clean("2.4", "REXML::DTD::ElementDecl", input), output
+  end
+end


### PR DESCRIPTION
RDoc's links are relative paths from the current file, where the path is the exact casing as the class, and end in .html.

These links work fine from the Objects#show page, but not on search results.
Additionally, they'll result in extra page caching, as the URL differs from what the app generates.

We can fix this by parsing the URLs, and having the router generate us a proper URL.

Fixes #361