### PR TITLE
Remove hover effect from class/instance method indicator

### DIFF
--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -37,10 +37,10 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
                     = seq
           div class="flex md:justify-end w-full md:w-2/12 mt-3 md:mt-0 font-mono"
             - if m.instance_method?
-              a class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current" title="Instance Method"
+              span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="Instance Method"
                 | #
             - elsif m.class_method?
-              a class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current" title="Class Method"
+              span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="Class Method"
                 | ::
             a class="px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current" href="#{github_url m}" target="_blank" rel="noopener" title="View source on Github"
               i class="fab fa-github"


### PR DESCRIPTION
The class/instance method indicators act like a link, but don't actually link anywhere. This actually confused me, because I thought it was supposed to do something.

They still look the same, but the cursor just remains an arrow, and nothing happens on hover.