### PR TITLE
Fix sidebar links

### DIFF
--- a/app/views/objects/_sidebar.html.slim
+++ b/app/views/objects/_sidebar.html.slim
@@ -6,14 +6,15 @@ div class="hidden lg:block w-1/4"
           = render "objects/sidebar/section/link",
               additional_classes: "font-mono text-sm",
               title: @object.superclass.constant,
-              href: @object.superclass.path
+              href: object_path(object: @object.superclass.path)
       - unless @object.included_modules.empty?
         = render "objects/sidebar/section", title: 'Included Modules' do
           ul class="font-mono text-sm"
             - @object.included_modules.each do |included_module|
               li
                 = render "objects/sidebar/section/link",
-                    title: included_module.constant, href: included_module.path
+                    title: included_module.constant,
+                    href: object_path(object: included_module.path)
       - unless @object.ruby_methods.select(&:class_method?).empty?
         = render "objects/sidebar/section", title: 'Class Methods' do
           ul class="font-mono text-sm"


### PR DESCRIPTION
Without running the links through the router, we end up with a path relative to the page we're currently on.

JSON::Ext::Generator::State has a superclass of Object

```ruby
irb(main):006:0> JSON::Ext::Generator::State.superclass
=> Object
```

See the "Parent" on https://rubyapi.org/2.7/o/json/ext/generator/state

The href generated for the Parent was /2.7/o/json/ext/generator/object when it should have been /2.7/o/object