### PR TITLE
Make the title be the full constant name

### DIFF
--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -1,5 +1,5 @@
 -# frozen_string_literal: true
-- title @object.name
+- title @object.constant
 - set_meta_tags canonical: object_url(object: @object.path, version: default_ruby_version) if default_ruby_version != ruby_version
 
 div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
@@ -10,7 +10,7 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
         div class="w-full md:w-6/12"
           h1 class="lg:text-3xl text-xl text-gray-800 dark:text-gray-200 font-semibold"
             a href="#{object_url(version: ruby_version, object: @object.path)}"
-              | #{@object.name}
+              | #{@object.constant}
         div class="w-full md:w-6/12 md:text-right mt-2 md:mt-0 cursor-default"
           - if @object.class_object?
             span class="py-1 px-2 rounded bg-gray-200 dark:bg-gray-700 text-sm"


### PR DESCRIPTION
On https://rubyapi.org/2.7/o/json/ext/generator/state

The title here previously said "State"
Now it says "JSON::Ext::Generator::State"

For class names that are not inside of a namespace (like "String"), the values of the `name` and `constant` are the same. But for namespaced classes, it makes a pretty big difference.

Before:
<img width="1792" alt="Screen Shot 2020-04-18 at 11 49 22 AM" src="https://user-images.githubusercontent.com/5104186/79643885-dfd4c080-816a-11ea-8c0e-92dc3fb85a4f.png">


After:
<img width="1792" alt="Screen Shot 2020-04-18 at 12 01 19 PM" src="https://user-images.githubusercontent.com/5104186/79644103-5b833d00-816c-11ea-99c1-6e24b83a4451.png">