### PR TITLE
Split class and instance methods in model

### DIFF
--- a/app/javascript/packs/app/application.scss
+++ b/app/javascript/packs/app/application.scss
@@ -36,7 +36,7 @@ pre {
 .ruby-operator { color: #5FB3B3; }
 
 p {
-  @apply py-3;
+  @apply my-3;
 }
 
 .overflow-wrap-break-word {

--- a/app/models/ruby_method.rb
+++ b/app/models/ruby_method.rb
@@ -23,12 +23,19 @@ class RubyMethod
     body[:object_constant]
   end
 
+  def class_method?
+    method_type == "class_method"
+  end
+
   def instance_method?
     method_type == "instance_method"
   end
 
-  def class_method?
-    method_type == "class_method"
+  def type_identifier
+    if class_method? then "::"
+    elsif instance_method? then "#"
+    else raise "Unknown type of method: #{method_type}"
+    end
   end
 
   def identifier
@@ -85,15 +92,5 @@ class RubyMethod
       alias: method_alias,
       metadata: metadata
     }
-  end
-
-  private
-
-  def type_identifier
-    if instance_method?
-      "#"
-    elsif class_method?
-      "::"
-    end
   end
 end

--- a/app/models/ruby_object.rb
+++ b/app/models/ruby_object.rb
@@ -60,6 +60,16 @@ class RubyObject
     @ruby_methods ||= body[:methods].collect { |m| RubyMethod.new(m) }
   end
 
+  def ruby_class_methods
+    @ruby_class_methods ||=
+      ruby_methods.select(&:class_method?).sort_by(&:name)
+  end
+
+  def ruby_instance_methods
+    @ruby_instance_methods ||=
+      ruby_methods.select(&:instance_method?).sort_by(&:name)
+  end
+
   def superclass
     return @superclass if defined?(@superclass)
 

--- a/app/views/objects/_sidebar.html.slim
+++ b/app/views/objects/_sidebar.html.slim
@@ -15,17 +15,17 @@ div class="hidden lg:block w-1/4"
                 = render "objects/sidebar/section/link",
                     title: included_module.constant,
                     href: object_path(object: included_module.path)
-      - unless @object.ruby_methods.select(&:class_method?).empty?
+      - unless @object.ruby_class_methods.empty?
         = render "objects/sidebar/section", title: 'Class Methods' do
           ul class="font-mono text-sm"
-            - @object.ruby_methods.select(&:class_method?).sort_by(&:name).each do |m|
+            - @object.ruby_class_methods.each do |m|
               li
                 = render "objects/sidebar/section/link",
                     title: ":: #{m.name}", href: "##{method_anchor(m)}"
-      - unless @object.ruby_methods.select(&:instance_method?).empty?
+      - unless @object.ruby_instance_methods.empty?
         = render "objects/sidebar/section", title: 'Instance Methods' do
           ul class="font-mono text-sm"
-            - @object.ruby_methods.select(&:instance_method?).sort_by(&:name).each do |m|
+            - @object.ruby_instance_methods.each do |m|
               li
                 = render "objects/sidebar/section/link",
                     title: "# #{m.name}", href: "##{method_anchor(m)}"

--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -5,7 +5,7 @@
 div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
   = render "objects/sidebar"
   div class="w-full mt-16 lg:mt-20 lg:w-3/4"
-    div class="md:p-3 py-3"
+    div class="m-3"
       div class="flex flex-wrap"
         div class="w-full md:w-6/12"
           h1 class="lg:text-3xl text-xl text-gray-800 dark:text-gray-200 font-semibold"
@@ -20,31 +20,9 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
               | Module
       div class="ruby-documentation"
         == @object.description
-    hr
-    - @object.ruby_methods.sort_by(&:name).each do |m|
-      div class="md:p-3 py-3 my-3"
-        a style="display: block; position: relative; top: -80px; visibility: hidden;" id="#{method_anchor m}"
-        div class="flex flex-wrap"
-          div class="w-full md:w-10/12"
-            a href="##{method_anchor(m)}"
-              - m.call_sequence.each do |seq|
-                h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= seq
-
-          div class="flex md:justify-end w-full md:w-2/12 mt-3 md:mt-0 font-mono"
-            - if m.instance_method?
-              span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="Instance Method"
-                | #
-            - elsif m.class_method?
-              span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="Class Method"
-                | ::
-            a class="px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 hover:text-gray-800 dark-hover:bg-gray-900 dark-hover:text-gray-400 hover:fill-current" href="#{github_url m}" target="_blank" rel="noopener" title="View source on Github"
-              i class="fab fa-github"
-        div class="ruby-documentation py-1"
-          - if m.alias?
-            div
-              | An alias for <a href="#{m.alias_path}" class="font-bold">#{m.alias_name}</a>
-          - elsif m.description.empty?
-            div
-              | No documentation available
-          - else
-            == m.description
+    - unless @object.ruby_class_methods.empty?
+      = render "objects/show/methods",
+          methods: @object.ruby_class_methods, title: "Class Methods"
+    - unless @object.ruby_instance_methods.empty?
+      = render "objects/show/methods",
+          methods: @object.ruby_instance_methods, title: "Instance Methods"

--- a/app/views/objects/show/_methods.html.slim
+++ b/app/views/objects/show/_methods.html.slim
@@ -1,0 +1,27 @@
+div class="md:px-3 my-3"
+  h3 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold mt-8"
+    = title
+  hr
+- methods.each do |m|
+  div class="md:px-3 my-3"
+    a style="display: block; position: relative; top: -80px; visibility: hidden;" id="#{method_anchor m}"
+    div class="flex flex-wrap"
+      div class="w-full md:w-10/12"
+        a href="##{method_anchor(m)}"
+          - m.call_sequence.each do |seq|
+            h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= seq
+
+      div class="flex md:justify-end w-full md:w-2/12 mt-3 md:mt-0 font-mono"
+        span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="#{m.method_type.capitalize} Method"
+          = m.type_identifier
+        a class="px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 hover:text-gray-800 dark-hover:bg-gray-900 dark-hover:text-gray-400 hover:fill-current" href="#{github_url m}" target="_blank" rel="noopener" title="View source on Github"
+          i class="fab fa-github"
+    div class="ruby-documentation py-1"
+      - if m.alias?
+        div
+          | An alias for <a href="#{m.alias_path}" class="font-bold">#{m.alias_name}</a>
+      - elsif m.description.empty?
+        div
+          | No documentation available
+      - else
+        == m.description

--- a/test/controllers/objects_controller_test.rb
+++ b/test/controllers/objects_controller_test.rb
@@ -78,7 +78,7 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
     string_info[:methods] << {
       name: "foo",
       description: "<h1>Hello World</h1>",
-      method_type: "instance_method",
+      method_type: "class_method",
       object_constant: "String",
       superclass: "Object",
       included_modules: [],
@@ -87,6 +87,16 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
         "foo(a,b)",
         "foo(arg1, arg2)"
       ]
+    }
+    string_info[:methods] << {
+      name: "bar",
+      description: "<h1>Hello World</h1>",
+      method_type: "instance_method",
+      object_constant: "String",
+      superclass: "Object",
+      included_modules: [],
+      source_location: "2.6.4:string.c:L3",
+      call_sequence: []
     }
 
     string = RubyObject.new(string_info)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,7 +2,7 @@
 
 class ApplicationHelperTest < ActionView::TestCase
   test "github_url" do
-    method = ruby_object(String).ruby_methods.first
-    assert_equal github_url(method), "https://github.com/ruby/ruby/blob/v2_6_4/string.c#L76"
+    method = ruby_object(String).ruby_class_methods.first
+    assert_equal github_url(method), "https://github.com/ruby/ruby/blob/v2_6_4/string.c#L3"
   end
 end

--- a/test/models/ruby_method_test.rb
+++ b/test/models/ruby_method_test.rb
@@ -23,6 +23,7 @@ class RubyMethodTest < ActiveSupport::TestCase
     }
 
     @method = RubyMethod.new(attributes)
+    @class_method = RubyMethod.new(method_type: "class_method")
   end
 
   test "required attribues" do
@@ -38,11 +39,12 @@ class RubyMethodTest < ActiveSupport::TestCase
 
   test "#instance_method?" do
     assert_equal @method.instance_method?, true
+    assert_equal @class_method.instance_method?, false
   end
 
   test "#class_method?" do
-    method = RubyMethod.new(method_type: "class_method")
-    assert_equal method.class_method?, true
+    assert_equal @class_method.class_method?, true
+    assert_equal @method.class_method?, false
   end
 
   test "#identifier" do

--- a/test/models/ruby_object_test.rb
+++ b/test/models/ruby_object_test.rb
@@ -18,6 +18,19 @@ class RubyObjectTest < ActiveSupport::TestCase
       },
       methods: [
         {
+          name: "new",
+          description: "<h1>Hello World</h1>",
+          method_type: "class_method",
+          object_constant: "String",
+          source_location: "2.6.4:string.c:L28",
+          metadata: {
+            depth: 1
+          },
+          call_sequence: <<~G
+            String.new # => ""
+          G
+        },
+        {
           name: "to_i",
           description: "<h1>Hello World</h1>",
           method_type: "instance_method",
@@ -68,8 +81,23 @@ class RubyObjectTest < ActiveSupport::TestCase
   end
 
   test "ruby_methods" do
-    method = @object.ruby_methods.first
-    assert_equal method.class, RubyMethod
+    assert_equal @object.ruby_methods.all? { |m| m.is_a?(RubyMethod) }, true
+  end
+
+  test "ruby_class_methods" do
+    assert_equal(
+      @object.ruby_class_methods.all? { |m| m.is_a?(RubyMethod) },
+      true
+    )
+    assert_equal @object.ruby_class_methods.all?(&:class_method?), true
+  end
+
+  test "ruby_instance_methods" do
+    assert_equal(
+      @object.ruby_instance_methods.all? { |m| m.is_a?(RubyMethod) },
+      true
+    )
+    assert_equal @object.ruby_instance_methods.all?(&:instance_method?), true
   end
 
   test "#to_hash" do
@@ -83,26 +111,45 @@ class RubyObjectTest < ActiveSupport::TestCase
       metadata: {
         depth: 1
       },
-      methods: [{
-        name: "to_i",
-        description: "<h1>Hello World</h1>",
-        type: :method,
-        autocomplete: "String#to_i",
-        object_constant: "String",
-        identifier: "String#to_i",
-        method_type: "instance_method",
-        source_location: "2.6.4:string.c:L54",
-        call_sequence: <<~G,
-          str.to_i # => 1
-        G
-        alias: {
-          path: "String.html#to_integer",
-          name: "to_integer"
+      methods: [
+        {
+          name: "new",
+          description: "<h1>Hello World</h1>",
+          type: :method,
+          autocomplete: "String::new",
+          object_constant: "String",
+          identifier: "String::new",
+          method_type: "class_method",
+          source_location: "2.6.4:string.c:L28",
+          metadata: {
+            depth: 1
+          },
+          call_sequence: <<~G,
+            String.new # => ""
+          G
+          alias: {}
         },
-        metadata: {
-          depth: 1
+        {
+          name: "to_i",
+          description: "<h1>Hello World</h1>",
+          type: :method,
+          autocomplete: "String#to_i",
+          object_constant: "String",
+          identifier: "String#to_i",
+          method_type: "instance_method",
+          source_location: "2.6.4:string.c:L54",
+          metadata: {
+            depth: 1
+          },
+          call_sequence: <<~G,
+            str.to_i # => 1
+          G
+          alias: {
+            path: "String.html#to_integer",
+            name: "to_integer"
+          }
         }
-      }],
+      ],
       name: "String",
       object_type: "class_object",
       superclass: "Object",

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,29 +52,41 @@ class ActiveSupport::TestCase
       metadata: {
         depth: 1
       },
-      methods: [{
-        name: "empty?",
-        description: "<h1>Hello World!</h1>",
-        method_type: "instance_method",
-        object_constant: constant.to_s,
-        source_location: "2.6.4:string.c:76",
-        metadata: {
-          depth: 1
-        },
-        call_sequence: []
-      }, {
-        name: "to_i",
-        description: "<h1>Hello World</h1>",
-        method_type: "instance_method",
-        object_constant: constant.to_s,
-        source_location: "2.6.4:string.c:54",
-        metadata: {
-          depth: 1
-        },
-        call_sequence: [
-          "str.to_i # => 1"
-        ]
-      }]
+      methods: [
+        {
+          name: "new",
+          description: "<h1>Hello World!</h1>",
+          method_type: "class_method",
+          object_constant: constant.to_s,
+          source_location: "2.6.4:string.c:3",
+          metadata: {
+            depth: 1
+          },
+          call_sequence: []
+        }, {
+          name: "empty?",
+          description: "<h1>Hello World!</h1>",
+          method_type: "instance_method",
+          object_constant: constant.to_s,
+          source_location: "2.6.4:string.c:76",
+          metadata: {
+            depth: 1
+          },
+          call_sequence: []
+        }, {
+          name: "to_i",
+          description: "<h1>Hello World</h1>",
+          method_type: "instance_method",
+          object_constant: constant.to_s,
+          source_location: "2.6.4:string.c:54",
+          metadata: {
+            depth: 1
+          },
+          call_sequence: [
+            "str.to_i # => 1"
+          ]
+        }
+      ]
     }
 
     RubyObject.new(attributes)


### PR DESCRIPTION
Show them separately on Object page, like on Ruby-Doc.org

Also sort them by name and cache.

Ruby-Doc.org version:

![image](https://user-images.githubusercontent.com/6510020/79677745-18bd7580-81fd-11ea-8133-1fabfcfbb158.png)

`master` version:

![image](https://user-images.githubusercontent.com/6510020/79677716-f166a880-81fc-11ea-9155-5017bbf9ec4d.png)

PR version:

![image](https://user-images.githubusercontent.com/6510020/79677731-05aaa580-81fd-11ea-9760-f672a37790f7.png)
