### PR TITLE
Fix incorrect Ruby Version in StandardRB config

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,7 +1,6 @@
 fix: true
 parallel: true
 format: progress
-ruby_version: 2.6
 default_ignores: true
 
 ignore:


### PR DESCRIPTION
RubyApi currently uses Ruby 2.7.1, so 2.6 is wrong.
But, the value defaults to the current ruby version (RUBY_VERSION).