### PR TITLE
Transition to GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - ruby
+  - dependencies
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - javascript
+  - dependencies
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+  - actions
+  - dependencies


### PR DESCRIPTION
Transitioning off of "depenabot-preview" (the dependabot.com version) and into the GitHub Dependabot ("dependabot").
https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

Additionally, have Dependabot submit PRs for updates to GitHub Actions. (I expect it to update actions/cache to v2, for example.)
https://github.blog/2020-06-25-dependabot-now-updates-your-actions-workflows/

Docs regarding the settings:
https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates

Once this PR is merged, you'll have a Dependabot tab on this page, which is where you can trigger Dependabot to check for updates again. https://github.com/rubyapi/rubyapi/network/dependencies

**Note:** This PR does expect you to create a `actions` label, for dependabot to add to PRs regarding GitHub Actions. https://github.com/rubyapi/rubyapi/labels