### PR TITLE
Fix some hovers on dark mode

### DIFF
--- a/app/views/layouts/_github_links.html.slim
+++ b/app/views/layouts/_github_links.html.slim
@@ -1,6 +1,6 @@
 -# frozen_string_literal: true
 div class="#{homepage? ? 'block' : 'hidden md:block'} relative ml-4" data-controller="github-links"
-  button class="relative z-20 text-xl hover:text-red-100 dark:hover:text-gray-400" data-action="click->github-links#toggle"
+  button class="relative z-20 text-xl hover:text-red-100 dark-hover:text-gray-400" data-action="click->github-links#toggle"
     i class="fab fa-github hover:fill-current"
   button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="github-links.linksOverlay" tabindex="-1" data-action="click->github-links#out"
   div class="dropdown absolute z-50 w-64 text-gray-700 bg-white dark:bg-gray-900 dark:text-gray-400 shadow-xl rounded py-2 right-0 invisible p-2 z-50" data-target="github-links.linksList"

--- a/app/views/layouts/_theme_selector.html.slim
+++ b/app/views/layouts/_theme_selector.html.slim
@@ -1,4 +1,4 @@
 -#frozen_string_literal: true
 div class="relative ml-4 md:block hidden" data-controller="theme-switch"
-    button id="darkmode-toggle" class="relative z-20 text-xl" data-action="theme-switch#toggle" aria-label="Toggle theme" title="Toggle theme"
+    button id="darkmode-toggle" class="relative z-20 text-xl hover:text-red-100 dark-hover:text-gray-400 hover:fill-current" data-action="theme-switch#toggle" aria-label="Toggle theme" title="Toggle theme"
         i class="fas fa-sun" data-target="theme-switch.switch"

--- a/app/views/layouts/_version_selector.html.slim
+++ b/app/views/layouts/_version_selector.html.slim
@@ -1,6 +1,6 @@
 -# frozen_string_literal: true
 div class="relative" data-controller="ruby-version"
-  button class="relative z-20 #{homepage? ? 'text-xl' : 'md:text-xl text-l'} pl-2 hover:text-red-100 dark:hover:text-gray-400 hover:fill-current" data-action="click->ruby-version#toggle" aria-label="Show github links"
+  button class="relative z-20 #{homepage? ? 'text-xl' : 'md:text-xl text-l'} pl-2 hover:text-red-100 dark-hover:text-gray-400 hover:fill-current" data-action="click->ruby-version#toggle" aria-label="Show github links"
     | #{ruby_version}
     i class="ml-2 fas fa-caret-down"
   button class="dropdown-overlay fixed inset-0 w-full h-full bg-black opacity-25 cursor-default invisible z-50" data-target="ruby-version.versionOverlay" tabindex="-1" data-action="click->ruby-version#out"

--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -42,7 +42,7 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
             - elsif m.class_method?
               span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="Class Method"
                 | ::
-            a class="px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 hover:text-gray-800 dark:hover:bg-gray-900 dark:hover:text-gray-400 hover:fill-current" href="#{github_url m}" target="_blank" rel="noopener" title="View source on Github"
+            a class="px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 hover:text-gray-800 dark-hover:bg-gray-900 dark-hover:text-gray-400 hover:fill-current" href="#{github_url m}" target="_blank" rel="noopener" title="View source on Github"
               i class="fab fa-github"
         div class="ruby-documentation py-1"
           - if m.description.empty?


### PR DESCRIPTION
Also, add a hover effect to the "theme switch" toggle

Before
<img width="222" alt="Screen Shot 2020-07-21 at 10 01 00 PM" src="https://user-images.githubusercontent.com/5104186/88188447-7b0f8300-cbfd-11ea-9d45-bd74e8a27c69.png">

After
<img width="178" alt="Screen Shot 2020-07-22 at 9 24 31 AM" src="https://user-images.githubusercontent.com/5104186/88188473-85318180-cbfd-11ea-8455-cec3692c7664.png">

Before
<img width="178" alt="Screen Shot 2020-07-22 at 9 25 41 AM" src="https://user-images.githubusercontent.com/5104186/88188491-89f63580-cbfd-11ea-84ec-90153910df97.png">

After
<img width="178" alt="Screen Shot 2020-07-22 at 9 25 32 AM" src="https://user-images.githubusercontent.com/5104186/88188513-924e7080-cbfd-11ea-9c34-844af3507d93.png">

Before (no hover effect on moon)
<img width="180" alt="Screen Shot 2020-07-22 at 9 25 55 AM" src="https://user-images.githubusercontent.com/5104186/88188553-a2665000-cbfd-11ea-953a-657f9184e01a.png">

After
<img width="166" alt="Screen Shot 2020-07-22 at 9 25 36 AM" src="https://user-images.githubusercontent.com/5104186/88188571-a85c3100-cbfd-11ea-8e09-59a4e6cf1ba0.png">

Before
<img width="87" alt="Screen Shot 2020-07-22 at 9 25 11 AM" src="https://user-images.githubusercontent.com/5104186/88188580-ad20e500-cbfd-11ea-9149-a5edace6c161.png">

After
<img width="108" alt="Screen Shot 2020-07-22 at 9 25 22 AM" src="https://user-images.githubusercontent.com/5104186/88188600-b14d0280-cbfd-11ea-95fe-718d949fe20e.png">

Before (no hover effect on sun)
<img width="158" alt="Screen Shot 2020-07-22 at 9 28 41 AM" src="https://user-images.githubusercontent.com/5104186/88188696-cfb2fe00-cbfd-11ea-92ff-be6afc289032.png">

After
<img width="153" alt="Screen Shot 2020-07-22 at 9 28 49 AM" src="https://user-images.githubusercontent.com/5104186/88188701-d2adee80-cbfd-11ea-94d0-eaa9d241f214.png">