### PR TITLE
Fix instance & class methods that share the same name in an object not correctly being imported

### DIFF
--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -52,7 +52,7 @@ class RubyAPIRDocGenerator
             depth: constant_depth(doc.full_name)
           }
         }
-        
+
         next if methods.find { |m| m[:name] == method[:name] && m[:method_type] == method[:method_type] }
 
         methods << method

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -53,7 +53,7 @@ class RubyAPIRDocGenerator
           }
         }
 
-        next if methods.find { |m| m[:name] == method[:name] && m[:method_type] == method[:method_type] }
+        next if methods.any? { |m| m[:name] == method[:name] && m[:method_type] == method[:method_type] }
 
         methods << method
       end

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -41,9 +41,7 @@ class RubyAPIRDocGenerator
       methods = []
 
       doc.method_list.each do |method_doc|
-        next if methods.find { |m| m[:name] == method_doc.name }
-
-        methods << {
+        method = {
           name: method_doc.name,
           description: clean_description(doc.full_name, method_doc.description),
           object_constant: doc.full_name,
@@ -54,6 +52,10 @@ class RubyAPIRDocGenerator
             depth: constant_depth(doc.full_name)
           }
         }
+        
+        next if methods.find { |m| m[:name] == method[:name] && m[:method_type] == method[:method_type] }
+
+        methods << method
       end
 
       superclass =


### PR DESCRIPTION
In the RDoc importer, we perform a small check to ensure we don't import a method with the same name multiple times. This check currently works by just looking at the method name. This check is preventing some legitimate methods that share the same name from being imported because they are different method types.

ie: `DateTime.rfc3339` and `DateTime#rfc3339`

This PR makes a small change to look at both the method name & method type when checking for duplicates.

Resolves #464 
