### PR TITLE
Prevent double-running the test suite on the first commit of a PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,21 @@
 name: CI
-on: [push,pull_request]
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths-ignore:
+      - '**.md'
+
 env:
   BUNDLE_PATH: vendor/bundle
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Also, don't run the test suite when a commit is only markdown files.

For example, look at the checks on https://github.com/rubyapi/rubyapi/pull/474
<img width="937" alt="Screen Shot 2020-07-25 at 11 25 00 PM" src="https://user-images.githubusercontent.com/5104186/88471351-19396c80-cece-11ea-869b-b5bf7d02ba29.png">
