### PR TITLE
Method aliases

### DIFF
--- a/app/models/ruby_method.rb
+++ b/app/models/ruby_method.rb
@@ -55,6 +55,22 @@ class RubyMethod
     body[:metadata]
   end
 
+  def alias?
+    method_alias.values.any?
+  end
+
+  def alias_path
+    method_alias[:path]
+  end
+
+  def alias_name
+    method_alias[:name]
+  end
+
+  def method_alias
+    body[:alias]
+  end
+
   def to_hash
     {
       name: name,
@@ -66,6 +82,7 @@ class RubyMethod
       method_type: method_type,
       source_location: source_location,
       call_sequence: call_sequence,
+      alias: method_alias,
       metadata: metadata
     }
   end

--- a/app/models/ruby_method.rb
+++ b/app/models/ruby_method.rb
@@ -68,7 +68,7 @@ class RubyMethod
   end
 
   def method_alias
-    body[:alias]
+    body[:alias] || {}
   end
 
   def to_hash

--- a/app/services/path_cleaner.rb
+++ b/app/services/path_cleaner.rb
@@ -1,0 +1,19 @@
+module PathCleaner
+  def self.clean(uri, constant:, version:)
+    class_parts = constant.split("::")[0..-2]
+
+    uri.path.delete_suffix(".html").split("/").each do |path_part|
+      if path_part == ".."
+        class_parts.pop
+      else
+        class_parts.push(path_part)
+      end
+    end
+
+    Rails.application.routes.url_helpers.object_path({
+      version: version,
+      object: class_parts.join("/").downcase,
+      anchor: uri.fragment
+    })
+  end
+end

--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -45,7 +45,10 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
             a class="px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 hover:text-gray-800 dark-hover:bg-gray-900 dark-hover:text-gray-400 hover:fill-current" href="#{github_url m}" target="_blank" rel="noopener" title="View source on Github"
               i class="fab fa-github"
         div class="ruby-documentation py-1"
-          - if m.description.empty?
+          - if m.alias?
+            div
+              | An alias for <a href="#{m.alias_path}" class="font-bold">#{m.alias_name}</a>
+          - elsif m.description.empty?
             div
               | No documentation available
           - else

--- a/lib/ruby_description_cleaner.rb
+++ b/lib/ruby_description_cleaner.rb
@@ -36,7 +36,7 @@ class RubyDescriptionCleaner < Trenni::Sanitize::Filter
       uri = URI(url)
       if uri.host.nil? && uri.path.present?
         # Only edit relative paths, but skip anchor-only paths.
-        node.tag.attributes["href"] = cleaned_href(uri)
+        node.tag.attributes["href"] = PathCleaner.clean(uri, constant: object_constant, version: version)
       end
     end
 
@@ -46,23 +46,5 @@ class RubyDescriptionCleaner < Trenni::Sanitize::Filter
     # Not a valid URL, so get rid of the <a> and just return the content.
     # EG: '<a href=":ssl">options</a>' becomes 'options'
     node.skip!(TAG)
-  end
-
-  def cleaned_href(uri)
-    class_parts = object_constant.split("::")[0..-2]
-
-    uri.path.delete_suffix(".html").split("/").each do |path_part|
-      if path_part == ".."
-        class_parts.pop
-      else
-        class_parts.push(path_part)
-      end
-    end
-
-    Rails.application.routes.url_helpers.object_path({
-      version: version,
-      object: class_parts.join("/").downcase,
-      anchor: uri.fragment
-    })
   end
 end

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -47,6 +47,10 @@ class RubyAPIRDocGenerator
           object_constant: doc.full_name,
           method_type: "#{method_doc.type}_method",
           source_location: "#{@release.version}:#{method_path(method_doc)}:#{method_doc.line}",
+          alias: {
+            path: clean_path(method_doc.is_alias_for&.path, constant: doc.full_name),
+            name: method_doc.is_alias_for&.name
+          },
           call_sequence: method_doc.call_seq ? method_doc.call_seq.strip.split("\n").map { |s| s.gsub "->", "→" } : "",
           metadata: {
             depth: constant_depth(doc.full_name)
@@ -123,5 +127,11 @@ class RubyAPIRDocGenerator
 
   def clean_description(method_class, description)
     RubyDescriptionCleaner.clean(@version, method_class, description)
+  end
+
+  def clean_path(path, constant:)
+    return nil unless path.present?
+
+    PathCleaner.clean(URI(path), constant: constant, version: @version)
   end
 end

--- a/test/models/ruby_method_test.rb
+++ b/test/models/ruby_method_test.rb
@@ -13,6 +13,10 @@ class RubyMethodTest < ActiveSupport::TestCase
       metadata: {
         depth: 1
       },
+      alias: {
+        path: "String.html#to_integer",
+        name: "to_integer"
+      },
       call_sequence: <<~G
         str.to_i # => 1
       G
@@ -45,22 +49,42 @@ class RubyMethodTest < ActiveSupport::TestCase
     assert_equal @method.identifier, "String#to_i"
   end
 
+  test "#method_is_alias?" do
+    method = RubyMethod.new(name: "size", alias: {path: "Array#length", name: "length"})
+    assert method.alias?
+  end
+
+  test "#alias_name" do
+    method = RubyMethod.new(name: "size", alias: {path: "Array.html#length", name: "length"})
+    assert_equal method.alias_name, "length"
+  end
+
+  test "#alias_path" do
+    method = RubyMethod.new(name: "size", alias: {path: "Array.html#length", name: "length"})
+    assert_equal method.alias_path, "Array.html#length"
+  end
+
   test "#to_hash" do
-    assert_equal @method.to_hash, {
-      name: "to_i",
-      description: "<h1>Hello World</h1>",
-      type: :method,
+    method_hash = @method.to_hash
+    assert_equal method_hash.sort.to_h, {
+      alias: {
+        name: "to_integer",
+        path: "String.html#to_integer"
+      },
       autocomplete: "String#to_i",
-      object_constant: "String",
+      call_sequence: <<~G,
+        str.to_i # => 1
+      G
+      description: "<h1>Hello World</h1>",
       identifier: "String#to_i",
-      method_type: "instance_method",
-      source_location: "2.6.4:string.c:L54",
       metadata: {
         depth: 1
       },
-      call_sequence: <<~G
-        str.to_i # => 1
-      G
+      method_type: "instance_method",
+      name: "to_i",
+      object_constant: "String",
+      source_location: "2.6.4:string.c:L54",
+      type: :method
     }
   end
 end

--- a/test/models/ruby_object_test.rb
+++ b/test/models/ruby_object_test.rb
@@ -26,9 +26,13 @@ class RubyObjectTest < ActiveSupport::TestCase
           metadata: {
             depth: 1
           },
-          call_sequence: <<~G
+          call_sequence: <<~G,
             str.to_i # => 1
           G
+          alias: {
+            path: "String.html#to_integer",
+            name: "to_integer"
+          }
         }
       ]
     }
@@ -69,15 +73,12 @@ class RubyObjectTest < ActiveSupport::TestCase
   end
 
   test "#to_hash" do
-    assert_equal @object.to_hash, {
-      id: "c3RyaW5n",
-      name: "String",
-      type: :object,
+    object_hash = @object.to_hash
+    assert_equal object_hash.sort.to_h, {
       autocomplete: "String",
       constant: "String",
-      object_type: "class_object",
       description: "<h1>Hello World</h1>",
-      superclass: "Object",
+      id: "c3RyaW5n",
       included_modules: ["Kernel"],
       metadata: {
         depth: 1
@@ -91,13 +92,21 @@ class RubyObjectTest < ActiveSupport::TestCase
         identifier: "String#to_i",
         method_type: "instance_method",
         source_location: "2.6.4:string.c:L54",
-        metadata: {
-          depth: 1
-        },
-        call_sequence: <<~G
+        call_sequence: <<~G,
           str.to_i # => 1
         G
-      }]
+        alias: {
+          path: "String.html#to_integer",
+          name: "to_integer"
+        },
+        metadata: {
+          depth: 1
+        }
+      }],
+      name: "String",
+      object_type: "class_object",
+      superclass: "Object",
+      type: :object
     }
   end
 end


### PR DESCRIPTION
This PR adds the functionality to import the alias information from ruby-src/rdoc & display that information to the user where applicable.

Before merging, one question I have is if a method is an alias but also has it's own documentation.  

Resolves #305 

<img width="1333" alt="Screen Shot 2020-08-12 at 11 48 39 pm" src="https://user-images.githubusercontent.com/996377/90023348-ffce5800-dcf6-11ea-808f-5cbffe4bc140.png">
