### PR TITLE
Use method arglists instead of name when a method does not have a documented call sequence

### DIFF
--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -32,8 +32,10 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
                   | #{m.name}
               - else
                 - m.call_sequence.each do |seq|
-                  h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
-                    = seq
+                  h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= seq
+            - else
+              h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
+                a href="##{method_anchor(m)}"= m.call_sequence
           div class="flex md:justify-end w-full md:w-2/12 mt-3 md:mt-0 font-mono"
             - if m.instance_method?
               span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="Instance Method"

--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -27,15 +27,9 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
         div class="flex flex-wrap"
           div class="w-full md:w-10/12"
             a href="##{method_anchor(m)}"
-              - if m.call_sequence.empty?
-                h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
-                  | #{m.name}
-              - else
-                - m.call_sequence.each do |seq|
-                  h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= seq
-            - else
-              h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
-                a href="##{method_anchor(m)}"= m.call_sequence
+              - m.call_sequence.each do |seq|
+                h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= seq
+
           div class="flex md:justify-end w-full md:w-2/12 mt-3 md:mt-0 font-mono"
             - if m.instance_method?
               span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="Instance Method"

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -51,7 +51,7 @@ class RubyAPIRDocGenerator
             path: clean_path(method_doc.is_alias_for&.path, constant: doc.full_name),
             name: method_doc.is_alias_for&.name
           },
-          call_sequence: method_doc.call_seq ? method_doc.call_seq.strip.split("\n").map { |s| s.gsub "->", "→" } : "",
+          call_sequence: call_sequence_for_method_doc(method_doc),
           metadata: {
             depth: constant_depth(doc.full_name)
           }
@@ -133,5 +133,15 @@ class RubyAPIRDocGenerator
     return nil unless path.present?
 
     PathCleaner.clean(URI(path), constant: constant, version: @version)
+  end
+
+  def call_sequence_for_method_doc(doc)
+    if doc.call_seq.present?
+      doc.call_seq.strip.split("\n").map { |s| s.gsub "->", "→" }
+    elsif doc.arglists.present?
+      doc.arglists.strip
+    else
+      ""
+    end
   end
 end

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -138,10 +138,10 @@ class RubyAPIRDocGenerator
   def call_sequence_for_method_doc(doc)
     if doc.call_seq.present?
       doc.call_seq.strip.split("\n").map { |s| s.gsub "->", "→" }
-    elsif doc.arglists.present?
-      doc.arglists.strip
+    elsif doc.arglists.present? && doc.arglists != "#{doc.name}()"
+      [doc.arglists.strip]
     else
-      ""
+      [doc.name]
     end
   end
 end

--- a/test/controllers/objects_controller_test.rb
+++ b/test/controllers/objects_controller_test.rb
@@ -51,6 +51,7 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
 
   test "show method name" do
     string_info = ruby_object(String).to_hash
+
     string_info[:methods] << {
       name: "foo",
       description: "<h1>Hello World</h1>",
@@ -59,7 +60,7 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
       superclass: "Object",
       included_modules: [],
       source_location: "2.6.4:string.c:L1",
-      call_sequence: []
+      call_sequence: "foo(a,b)"
     }
 
     string = RubyObject.new(string_info)
@@ -68,6 +69,33 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
 
     get object_url object: string.path
 
-    assert_select "h4", "foo"
+    assert_select "h4", "foo(a,b)"
+  end
+
+  test "multiline call sequence" do
+    string_info = ruby_object(String).to_hash
+
+    string_info[:methods] << {
+      name: "foo",
+      description: "<h1>Hello World</h1>",
+      method_type: "instance_method",
+      object_constant: "String",
+      superclass: "Object",
+      included_modules: [],
+      source_location: "2.6.4:string.c:L1",
+      call_sequence: [
+        "foo(a,b)",
+        "foo(arg1, arg2)"
+      ]
+    }
+
+    string = RubyObject.new(string_info)
+
+    index_object string
+
+    get object_url object: string.path
+
+    assert_select "h4", "foo(a,b)"
+    assert_select "h4", "foo(arg1, arg2)"
   end
 end

--- a/test/controllers/objects_controller_test.rb
+++ b/test/controllers/objects_controller_test.rb
@@ -60,7 +60,7 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
       superclass: "Object",
       included_modules: [],
       source_location: "2.6.4:string.c:L1",
-      call_sequence: "foo(a,b)"
+      call_sequence: ["foo(a,b)"]
     }
 
     string = RubyObject.new(string_info)


### PR DESCRIPTION
Lots of methods currently are only be shown with their name, so no arguments or return information for the user. We ideally want to provide as much information that we have. This PR updates the import process to pull the `arglists` if there is no `call_sequence`.

**Before:**

![](https://user-images.githubusercontent.com/6510020/89025487-a007a280-d32f-11ea-9eb3-4a17fc430f1f.png)

**After:**

<img width="1289" alt="Screen Shot 2020-08-13 at 7 15 16 pm" src="https://user-images.githubusercontent.com/996377/90116785-59875e80-dd99-11ea-8f0a-42d7c6f4bf19.png">

Resolves #492 