### PR TITLE
Fix empty call sequence (alias methods) links

### DIFF
--- a/app/views/objects/show.html.slim
+++ b/app/views/objects/show.html.slim
@@ -26,12 +26,11 @@ div class="max-w-screen-xl mx-auto px-3 md:px-0 lg:flex"
         a style="display: block; position: relative; top: -80px; visibility: hidden;" id="#{method_anchor m}"
         div class="flex flex-wrap"
           div class="w-full md:w-10/12"
-            - if m.call_sequence.empty?
-              h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
-                a href="##{method_anchor(m)}"
-                | #{m.name}
-            - else
-              a href="##{method_anchor(m)}"
+            a href="##{method_anchor(m)}"
+              - if m.call_sequence.empty?
+                h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
+                  | #{m.name}
+              - else
                 - m.call_sequence.each do |seq|
                   h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"
                     = seq


### PR DESCRIPTION
Improper tabbing of the anchor content produced this HTML:

```html
<h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold">
  <a href="#method-i-append"></a>
  append
</h4>
```

Since the <a> is empty, the "append" is not a link.

DRYing the code (consolidating the <a>) now produces the following HTML:

```html
<a href="#method-i-append">
  <h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold">append</h4>
</a>
```

Now, call sequence or not, the <a> is always on the outside with 1 or more `<h4>`s inside.

Example:
https://rubyapi.org/2.7/o/array#method-i-append

<img width="1680" alt="Screen Shot 2020-08-29 at 11 03 39 PM" src="https://user-images.githubusercontent.com/5104186/91650970-278a2380-ea4c-11ea-8960-1d86fb24ba18.png">


<img width="563" alt="Screen Shot 2020-08-29 at 11 03 58 PM" src="https://user-images.githubusercontent.com/5104186/91650971-2a851400-ea4c-11ea-9142-7eae31ded494.png">
