### PR TITLE
Correctly exclude all Bundler, IRB and RDoc classes during import

### DIFF
--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -4,9 +4,9 @@ require_relative "ruby_description_cleaner"
 
 class RubyAPIRDocGenerator
   SKIP_NAMESPACES = [
-    /Bundler::.*/,
-    /RDoc::.*/,
-    /IRB::.*/
+    /Bundler.*/,
+    /RDoc.*/,
+    /IRB.*/
   ].freeze
 
   SKIP_NAMESPACE_REGEX = Regexp.union(SKIP_NAMESPACES).freeze


### PR DESCRIPTION
Currently the root `Bundler`, `RDoc`, and `IRB` modules are being imported. We want to exclude these as well.

<img width="815" alt="Screen Shot 2020-09-01 at 11 22 25 pm" src="https://user-images.githubusercontent.com/996377/91856528-06bf0980-ecaa-11ea-9b12-b5227bd6fa33.png">
