### PR TITLE
Improve methods bottom margin

### DIFF
--- a/app/javascript/packs/app/application.scss
+++ b/app/javascript/packs/app/application.scss
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 pre.ruby {
-  @apply p-3 rounded-b rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
+  @apply p-3 mb-3 rounded-b rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
 }
 
 pre {


### PR DESCRIPTION
There was a smaller bottom margin for methods with a code block at the end.

Before:

![image](https://user-images.githubusercontent.com/6510020/92626791-11ddef00-f2d3-11ea-8814-9dcd2729168f.png)


After:

![image](https://user-images.githubusercontent.com/6510020/92626862-31751780-f2d3-11ea-80a0-f811b3193801.png)

