### PR TITLE
Run StandardRB for Ruby 3

### DIFF
--- a/app/services/search/query.rb
+++ b/app/services/search/query.rb
@@ -2,7 +2,7 @@
 
 module Search
   class Query
-    QUERY_OPTION_PATTERN = /\w+:\w+/.freeze
+    QUERY_OPTION_PATTERN = /\w+:\w+/
 
     attr_reader :query
 

--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -10,7 +10,7 @@ class RubyAPIRDocGenerator
     IRB
   ].freeze
 
-  SKIP_NAMESPACE_REGEX = /^(#{SKIP_NAMESPACES.join('|')})($|::.+)/.freeze
+  SKIP_NAMESPACE_REGEX = /^(#{SKIP_NAMESPACES.join('|')})($|::.+)/
 
   def class_dir
   end


### PR DESCRIPTION
Regex literals are frozen by default, and don't need an explicit freeze.