### PR TITLE
Fix ruby 3.0.0 import

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ ./bin/webpack-dev-server
 Ruby's documentation can be imported very easily. There's a rake task that will let you import a given versions' documentation:
 
 ```sh
-$ ./bin/rake import:ruby[2.6.4]
+$ ./bin/rake import:ruby[3.0.0]
 ```
 
 or you can easily import the latest versions of all currently supported versions of ruby:

--- a/app/services/ruby_releases/release_list.rb
+++ b/app/services/ruby_releases/release_list.rb
@@ -43,7 +43,7 @@ module RubyReleases
     end
 
     def ruby_3
-      RubyVersion.new("3.0-preview1", source_url: "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0-preview1.zip")
+      RubyVersion.new("3.0.0", source_url: "https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.0.zip")
     end
 
     def supported_release_format?(url)


### PR DESCRIPTION
Unfortunately the ruby 3.0.0 release has not been added to the [Ruby Releases index](https://cache.ruby-lang.org/pub/ruby/index.txt), which means that importing Ruby 3.0 docs via `./bin/rake import:ruby[3.0.0]` doesn't currently work without `FORCE_RUBY_DOWNLOAD_URL` being set. This PR resolves this indirectly by adding an entry for Ruby 3.0.0.
