### PR TITLE
Enable Sentry's breadcrumbs loggers

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,4 @@
 Sentry.init do |config|
   config.dsn = ENV["SENTRY_DSN"]
+  config.breadcrumbs_logger = [:active_support_logger, :sentry_logger]
 end


### PR DESCRIPTION
Hey I'm a big fan of `rubyapi` and have replaced ruby-doc with it in my daily development for a while. Thanks for the amazing work 👍 

I also maintain [sentry-ruby](https://github.com/getsentry/sentry-ruby) and was surprised to see that this project uses Sentry as well. So I figure I can make a small contribution to improve your debugging experience with Sentry.

In this PR, I enabled 2 of the SDK's breacrumbs loggers, which are very helpful for debugging:

- `sentry_logger` captures breadcrumbs from logging events. Helpful for recording activities from other libraries.
- `active_support_logger` captures breadcrumbs from Rails  instrumentations. 

This is an example after adding breadcrumbs section:

<img width="70%" alt="rubyapi breadcrumbs" src="https://user-images.githubusercontent.com/5079556/115858402-7c5a2e80-a461-11eb-8796-6e4e736edd6e.png">

BTW, this feature **won't** consume you more quota and **doesn't** require any change on billing 😄 

Let me know if you have any question/request related to Sentry, I'll be happy to help 😎 

