### PR TITLE
Mark Ruby 2.5 as EOL

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module RubyApi
       3.0 2.7 2.6 2.5 2.4 2.3 dev
     ]
 
-    config.eol_ruby_versions = %w[2.4 2.3]
+    config.eol_ruby_versions = %w[2.5 2.4 2.3]
 
     config.elasticsearch_shards = ENV.fetch('ELASTICSEARCH_SHARDS', 5).to_i
     config.elasticsearch_replicas = ENV.fetch('ELASTICSEARCH_REPLICAS', 1).to_i


### PR DESCRIPTION
As of the release of Ruby 2.5.9 on 2021-04-05, the 2.5.x series is EOL:
https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/