### PR TITLE
Allow arrow keys to "wrap around" search suggestions

### DIFF
--- a/app/javascript/controllers/app/search_controller.js
+++ b/app/javascript/controllers/app/search_controller.js
@@ -115,7 +115,7 @@ export default class extends Controller {
     }
 
     const max = this.suggestionsLength()
-    this.suggestionIndex = this.wrap(this.suggestionIndex, max + 1)
+    this.suggestionIndex = this.wrap(this.suggestionIndex, max)
 
     this.highlightSelectedSuggestion()
   }
@@ -152,8 +152,7 @@ export default class extends Controller {
   }
 
   wrap(value, max) {
-    const mod = value % max;
-    return mod < 0 ? mod + max : mod
+    return value < 0 ? max : (value > max ? 0 : value)
   }
 
   suggestionsLength() {

--- a/app/javascript/controllers/app/search_controller.js
+++ b/app/javascript/controllers/app/search_controller.js
@@ -115,7 +115,7 @@ export default class extends Controller {
     }
 
     const max = this.suggestionsLength()
-    this.suggestionIndex = this.clamp(this.suggestionIndex, 0, max)
+    this.suggestionIndex = this.wrap(this.suggestionIndex, max + 1)
 
     this.highlightSelectedSuggestion()
   }
@@ -151,8 +151,9 @@ export default class extends Controller {
       })
   }
 
-  clamp(value, min, max) {
-    return Math.min(max, Math.max(min, value))
+  wrap(value, max) {
+    const mod = value % max;
+    return mod < 0 ? mod + max : mod
   }
 
   suggestionsLength() {


### PR DESCRIPTION
If the user wants to select the last search suggestion, instead of
pressing down a bunch of times, now they can just press up once.

Conversely, if the user has the final search suggestion
selected/highlighted, they can press down to bring themselves back to
the neutral/starting point where no suggestion is selected.