### PR TITLE
Fix overzealous regex in `RubyDescriptionCleaner`

### DIFF
--- a/lib/ruby_description_cleaner.rb
+++ b/lib/ruby_description_cleaner.rb
@@ -8,8 +8,8 @@ class RubyDescriptionCleaner < Trenni::Sanitize::Filter
     # Most of this method is copy/pasted from Trenni::Sanitize::Filter.parse
     # https://github.com/ioquatix/trenni-sanitize/blob/c8e08d2717b98a2268da89f8196fdb1eb93725bf/lib/trenni/sanitize/filter.rb#L40
 
-    description = description.gsub(/(<a.*&para;<\/a>)/, "")
-      .gsub(/(<a.*&uarr;<\/a>)/, "")
+    description = description.gsub(/(<a[^>]*>&para;<\/a>)/, "")
+      .gsub(/(<a[^>]*>&uarr;<\/a>)/, "")
       .gsub("<pre class=\"ruby\">", "<div class=\"ruby\" data-controller=\"code-example\" data-target=\"code-example.block\" data-code-example-version=\"#{version}\"></div><pre class=\"ruby\">")
       .gsub(/<a.*?href=""\w+"".*?>(.+?)<\/a>/, "\\1")
 

--- a/test/lib/ruby_description_cleaner_test.rb
+++ b/test/lib/ruby_description_cleaner_test.rb
@@ -69,4 +69,18 @@ class RubyDescriptionCleanerTest < ActiveSupport::TestCase
       assert_equal RubyDescriptionCleaner.clean("2.4", "REXML::DTD::ElementDecl", input), output
     end
   end
+
+  test "trim paragraph and up arrow links" do
+    input = <<~HTML
+      <h2 id="class-Array-label-Obtaining+Information+about+an+Array">Obtaining Information about an <a href="Array.html"><code>Array</code></a><span><a href="#class-Array-label-Obtaining+Information+about+an+Array">&para;</a> <a href="#top">&uarr;</a></span></h2>
+    HTML
+
+    expected_output = <<~HTML
+      <h2 id="class-Array-label-Obtaining+Information+about+an+Array">Obtaining Information about an <a href="/2.7/o/array"><code>Array</code></a><span> </span></h2>
+    HTML
+
+    capture_io do
+      assert_equal expected_output, RubyDescriptionCleaner.clean("2.7", "Array", input)
+    end
+  end
 end


### PR DESCRIPTION
The `.*` in these regexes can match more than we expect and cause
problems. Specifically, there's nothing preventing them from comsuming
multiple `<a>` tags which is exactly what happens on some pages (e.g.,
`Array`, `DateTime`, etc.). This commit constrains these regexes so that
they can only match (and thus delete) a single `<a>` tag.

---

Examples of this regex causing problems:

- `Array`
  - https://rubyapi.org/3.0/o/array#class-Array-label-Obtaining+Information+about+an+Array
  - https://ruby-doc.org/core-3.0.0/Array.html#class-Array-label-Obtaining+Information+about+an+Array
- `DateTime`
  - https://rubyapi.org/3.0/o/datetime#class-DateTime-label-When+should+you+use+DateTime+and+when+should+you+use+Time-3F
  - https://ruby-doc.org/stdlib-3.0.1/libdoc/date/rdoc/DateTime.html#class-DateTime-label-When+should+you+use+DateTime+and+when+should+you+use+Time-3F