### PR TITLE
Use setup-ruby to manage gem cache instead of the cache action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get -yqq install chromium-chromedriver
-          gem install bundler --no-doc
           yarn install --frozen-lockfile
-          bundle install --jobs 4 --retry 3
 
       - name: Compile Assets
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,8 @@ jobs:
 
       - name: Set Up Ruby
         uses: ruby/setup-ruby@v1
-
-      - name: Cache Gems
-        uses: actions/cache@v2
         with:
-          path: vendor/bundle
-          key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            bundler-cache-
+          bundler-cache: true
 
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
The [setup-ruby](https://github.com/ruby/setup-ruby) action has the ability to cache gems. We should use it to simplify our Github Actions template