### PR TITLE
Separate lint & test steps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,7 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get -yqq install chromium-chromedriver
-          gem install bundler --no-doc
           yarn install --frozen-lockfile
-          bundle install --jobs 4 --retry 3
 
       - name: Compile Assets
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   lint:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,18 @@ env:
   BUNDLE_PATH: vendor/bundle
 
 jobs:
+  lint:
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      
+      - name: Run linting
+        run: ./bin/standardrb --no-fix
+          
   build:
     runs-on: ubuntu-latest
     services:
@@ -62,9 +74,7 @@ jobs:
         run: |
           bundle exec rake webpacker:compile
 
-      - name: Run Tests & Linting
+      - name: Run Tests
         env:
           ELASTICSEARCH_URL: "http://localhost:9200"
-        run: |
-          ./bin/standardrb --no-fix
-          ./bin/rake test
+        run: ./bin/rake test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,8 @@ jobs:
 
       - name: Set Up Ruby
         uses: ruby/setup-ruby@v1
-
-      - name: Cache Gems
-        uses: actions/cache@v2
         with:
-          path: vendor/bundle
-          key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            bundler-cache-
+          bundler-cache: true
 
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
Our Github Actions template was a bit complex because we checked linting and app testing inside a single job. This PR should help remove some of that complexity by splitting the 2 tasks into separate jobs in Github Actions.


Depends on #775 