### PR TITLE
Add test-import check to Github actions to test importing ruby documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Run Tests
+      - name: Test Importing Ruby Documentation
         env:
           ELASTICSEARCH_URL: "http://localhost:9200"
         run: ./bin/rake "import:ruby[dev]"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,36 @@ jobs:
       
       - name: Run linting
         run: ./bin/standardrb --no-fix
-          
-  build:
+
+  test-import:
+    runs-on: ubuntu-latest
+    services:
+      elasticsearch:
+        image: elasticsearch:7.3.2
+        ports:
+          - 9200:9200
+        env:
+          "discovery.type": "single-node"
+        options: >-
+          --health-cmd "curl --silent --fail localhost:9200/_cluster/health || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run Tests
+        env:
+          ELASTICSEARCH_URL: "http://localhost:9200"
+        run: ./bin/rake "import:ruby[dev]"
+
+  test:
     runs-on: ubuntu-latest
     services:
       elasticsearch:


### PR DESCRIPTION
We currently don't have any tests to verify the `import:ruby` rake task works, we have some unit tests, but it only covers little bits of the import functionality.

This PR adds a new step that runs an import to ensure the entire process works when making changes.