### PR TITLE
Make datatables more friendly for desktop users

### DIFF
--- a/app/javascript/packs/app/application.scss
+++ b/app/javascript/packs/app/application.scss
@@ -114,20 +114,6 @@ pre:not(.ruby) {
     @apply border-0;
   }
 
-  @screen lg {
-    dt, dd {
-      @apply border-b-2 border-gray-400 text-center;
-    }
-
-    dd {
-      @apply w-10/12 px-3;
-    }
-
-    dt {
-      @apply w-2/12 p-3;
-    }
-  }
-
   h1, h2, h3, h4, h5 {
     @apply font-semibold text-lg py-1;
   }


### PR DESCRIPTION
Some of the datatables in the Ruby documentation isn't rendering nicely on desktops due to the header being long.

<img width="1149" alt="Screen Shot 2021-05-28 at 10 54 35 pm" src="https://user-images.githubusercontent.com/996377/119993388-d759e500-c00e-11eb-926f-344c3fb9419b.png">

The quick fix would be to remove the desktop styles and use the mobile layout for all devices, it would allow the header to be any length and not worry about dynamic cell sizes, but I'm really on the fence.

<img width="1175" alt="Screen Shot 2021-05-28 at 10 56 21 pm" src="https://user-images.githubusercontent.com/996377/119994391-e8572600-c00f-11eb-91cf-ce3cb85b3bb1.png">
