### PR TITLE
Don't link to objects in the sidebar which do not exist

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,14 @@ class ApplicationController < ActionController::Base
   end
   helper_method :home_path
 
+  def object_exists?(klass)
+    path = klass.is_a?(RubyObject) ? klass.id : RubyObject.id_from_path(klass)
+    !!RubyObjectRepository.repository_for_version(ruby_version).find(path)
+  rescue Elasticsearch::Persistence::Repository::DocumentNotFound
+    false
+  end
+  helper_method :object_exists?
+
   def skip_session
     request.session_options[:skip] = true
   end

--- a/app/views/objects/_sidebar.html.slim
+++ b/app/views/objects/_sidebar.html.slim
@@ -5,7 +5,7 @@
         = render "objects/sidebar/section/link",
             additional_classes: "font-mono text-sm",
             title: @object.superclass.constant,
-            href: object_path(object: @object.superclass.path)
+            href: object_exists?(@object.superclass) ? object_path(object: @object.superclass.path) : "#"
     - unless @object.included_modules.empty?
       = render "objects/sidebar/section", title: 'Included Modules' do
         ul class="font-mono text-sm"
@@ -13,7 +13,7 @@
             li
               = render "objects/sidebar/section/link",
                   title: included_module.constant,
-                  href: object_path(object: included_module.path)
+                  href: object_exists?(included_module) ? object_path(object: included_module.path) : "#"
     - unless @object.ruby_constants.empty?
       = render "objects/sidebar/section", title: 'Constants' do
         ul class="font-mono text-sm"
@@ -45,7 +45,7 @@ div class="hidden lg:block w-1/4"
           = render "objects/sidebar/section/link",
               additional_classes: "font-mono text-sm",
               title: @object.superclass.constant,
-              href: object_path(object: @object.superclass.path)
+              href: object_exists?(@object.superclass) ? object_path(object: @object.superclass.path) : "#"
       - unless @object.included_modules.empty?
         = render "objects/sidebar/section", title: 'Included Modules' do
           ul class="font-mono text-sm"
@@ -53,7 +53,7 @@ div class="hidden lg:block w-1/4"
               li
                 = render "objects/sidebar/section/link",
                     title: included_module.constant,
-                    href: object_path(object: included_module.path)
+                    href: object_exists?(included_module) ? object_path(object: included_module.path) : "#"
       - unless @object.ruby_constants.empty?
         = render "objects/sidebar/section", title: 'Constants' do
           ul class="font-mono text-sm"


### PR DESCRIPTION
We shouldn't create links to objects which the documentation refers to, but we don't have a page for

Resolves #481 