### PR TITLE
Fix: github url is invalid on dev & 3.1 version

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,11 +16,14 @@ module ApplicationHelper
   # Map a method source file into a url to Github.com
   def github_url(ruby_doc)
     version, file, line = ruby_doc.source_location.split(":")
-    version = "v#{version.tr(".", "_")}" unless version == DEV
 
+    if version == DEV
     # Not using URI.join, for a performance optimization. URI.join does A LOT of allocations.
     # We know that our source_location is safe, because we make it in the importer.
     # Inspiration: https://github.com/rack/rack/pull/1202
-    %(#{GITHUB_REPO}/#{version}/#{file}#{"#L#{line}" if line})
+      %(#{GITHUB_REPO}/master/#{file}#{"#L#{line}" if line})
+    else
+      %(#{GITHUB_REPO}/v#{version.tr(".", "_")}/#{file}#{"#L#{line}" if line})
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,9 +18,9 @@ module ApplicationHelper
     version, file, line = ruby_doc.source_location.split(":")
 
     if version == DEV
-    # Not using URI.join, for a performance optimization. URI.join does A LOT of allocations.
-    # We know that our source_location is safe, because we make it in the importer.
-    # Inspiration: https://github.com/rack/rack/pull/1202
+      # Not using URI.join, for a performance optimization. URI.join does A LOT of allocations.
+      # We know that our source_location is safe, because we make it in the importer.
+      # Inspiration: https://github.com/rack/rack/pull/1202
       %(#{GITHUB_REPO}/master/#{file}#{"#L#{line}" if line})
     else
       %(#{GITHUB_REPO}/v#{version.tr(".", "_")}/#{file}#{"#L#{line}" if line})

--- a/app/services/ruby_releases/release_list.rb
+++ b/app/services/ruby_releases/release_list.rb
@@ -14,7 +14,7 @@ module RubyReleases
 
     attr_accessor :releases
     def initialize
-      @releases = parse_index(release_index).push(dev, ruby_31)
+      @releases = parse_index(release_index).push(dev)
     end
 
     private
@@ -38,10 +38,6 @@ module RubyReleases
 
     def dev
       RubyVersion.new("dev", sha512: "", source_url: RUBY_DEV_ZIP_URL)
-    end
-
-    def ruby_31
-      RubyVersion.new("3.1", source_url: "https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.0.zip")
     end
 
     def supported_release_format?(url)

--- a/test/services/ruby_releases/release_list_test.rb
+++ b/test/services/ruby_releases/release_list_test.rb
@@ -43,6 +43,6 @@ class RubyReleases::RubyReleasesListTest < ActiveSupport::TestCase
 
   test "fetching ruby releases" do
     releases = RubyReleases::ReleaseList.fetch
-    assert_equal releases.size, 8 # Note: a release for 'dev' & Ruby 3 is automatically added
+    assert_equal releases.size, 7 # Note: a release for 'dev' is automatically added
   end
 end


### PR DESCRIPTION
The `ruby_31` version is parsed as '3.1' which has no patch part('3.1.1'),that causes the `github_url` result is invalid(https://github.com/ruby/ruby/blob/v3_1/object.c).

The same problem happens on dev version,because there is no tag or branch named `dev`.

This pr lets the `View on GitHub` guide to valid url on dev & 3.1 version.
![image](https://user-images.githubusercontent.com/47747466/156015863-7f6f6b0d-f5f3-48b7-b522-0f33a05ec7e6.png)
