### PR TITLE
Make the browser's theme-color match the site's header

### DIFF
--- a/app/javascript/controllers/app/theme-switch_controller.js
+++ b/app/javascript/controllers/app/theme-switch_controller.js
@@ -32,6 +32,7 @@ const setDarkMode = (target) => {
   }
 
   document.documentElement.classList.add("dark")
+  setMetaThemeColor('#374151')
   localStorage.setItem('rubyapi-darkMode', '1')
 }
 
@@ -42,7 +43,15 @@ const setLightMode = (target) => {
   }
 
   document.documentElement.classList.remove("dark")
+  setMetaThemeColor('#e1175a')
   localStorage.setItem('rubyapi-darkMode', '0')
+}
+
+const setMetaThemeColor = (color) => {
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) {
+    meta.content = color
+  }
 }
 
 export default class extends Controller {


### PR DESCRIPTION
Instead of always being red, make it toggle between red and gray.


# Before
<img width="1840" alt="Screen Shot 2022-05-12 at 12 03 22 AM" src="https://user-images.githubusercontent.com/5104186/167995873-df9e412c-b57b-4472-8d1f-8c2d4ba2167a.png">
<img width="1840" alt="Screen Shot 2022-05-12 at 12 03 25 AM" src="https://user-images.githubusercontent.com/5104186/167995884-2ad385ca-9992-4359-8e3c-b6fbffac943b.png">

# After
<img width="1840" alt="Screen Shot 2022-05-12 at 12 03 31 AM" src="https://user-images.githubusercontent.com/5104186/167995901-c3b1dbbc-9b6e-40e7-b182-e8ab1cdf1e31.png">
<img width="1840" alt="Screen Shot 2022-05-12 at 12 03 34 AM" src="https://user-images.githubusercontent.com/5104186/167995912-d8f33915-9f3d-41d5-8751-ad4223b6fcd2.png">

