### PR TITLE
Add stimulus reflex and setup foundation for toggling method type signatures 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v3
@@ -78,6 +85,13 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,10 +47,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      redis:
-        image: redis
+      cache:
+        image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      database:
+        image: postgres:14.3-alpine
+        env:
+          "POSTGRES_HOST_AUTH_METHOD": "trust"
+        options: >-
+          --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -85,10 +94,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-      redis:
-        image: redis
+      cache:
+        image: redis:7-alpine
         options: >-
           --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      database:
+        image: postgres:14.3-alpine
+        env:
+          POSTGRES_PASSWORD: POSTGRES_HOST_AUTH_METHOD=trust
+        options: >-
+          --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,5 +143,6 @@ jobs:
         env:
           ELASTICSEARCH_URL: "http://localhost:9200"
         run: |
+          ./bin/rails db:create
           ./bin/yarn build && ./bin/yarn build:css
           ./bin/rails test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   BUNDLE_PATH: vendor/bundle
+  RAILS_ENV: test
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,8 @@ jobs:
           --health-retries 10
       cache:
         image: redis:7-alpine
+        ports:
+          - "6379:6379"
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -57,6 +59,8 @@ jobs:
           --health-retries 5
       database:
         image: postgres:14.3-alpine
+        ports:
+          - "5432:5432"
         env:
           "POSTGRES_HOST_AUTH_METHOD": "trust"
           "POSTGRES_USER": "rubyapi"
@@ -98,6 +102,8 @@ jobs:
           --health-retries 10
       cache:
         image: redis:7-alpine
+        ports:
+          - "6379:6379"
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -105,6 +111,8 @@ jobs:
           --health-retries 5
       database:
         image: postgres:14.3-alpine
+        ports:
+          - "5432:5432"
         env:
           "POSTGRES_HOST_AUTH_METHOD": "trust"
           "POSTGRES_USER": "rubyapi"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
         image: postgres:14.3-alpine
         env:
           "POSTGRES_HOST_AUTH_METHOD": "trust"
+          "POSTGRES_USER": "rubyapi"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -104,7 +105,8 @@ jobs:
       database:
         image: postgres:14.3-alpine
         env:
-          POSTGRES_PASSWORD: POSTGRES_HOST_AUTH_METHOD=trust
+          "POSTGRES_HOST_AUTH_METHOD": "trust"
+          "POSTGRES_USER": "rubyapi"
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "hiredis"
 gem "jsbundling-rails"
 gem "cssbundling-rails"
 gem "propshaft"
+gem "pg"
 
 gem "elasticsearch-persistence"
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,39 +2,39 @@ source "https://rubygems.org"
 
 ruby "~> 3.0"
 
-group :preload, :default do
-  gem "rails", "~> 7.0.3"
-  gem "bootsnap", ">= 1.1.0", require: false
-  gem "falcon"
-  gem "redis", "~> 4.6"
-  gem "hiredis"
-  gem "jsbundling-rails"
-  gem "cssbundling-rails"
-  gem "propshaft"
+gem "rails", "~> 7.0.2"
+gem "bootsnap", ">= 1.1.0", require: false
+gem "redis", "~> 4.6"
+gem "puma"
+gem "hiredis"
+gem "jsbundling-rails"
+gem "cssbundling-rails"
+gem "propshaft"
 
-  gem "elasticsearch-persistence"
+gem "elasticsearch-persistence"
 
-  gem "http"
-  gem "typhoeus", require: false
-  gem "kaminari", "~> 1.2.2"
-  gem "inline_svg"
-  gem "tty-spinner", require: false
-  gem "skylight", group: :production
-  gem "graphql"
-  gem "graphiql-rails", group: :development
-  gem "lograge"
-  gem "logstash-event"
-  gem "aws-sdk-s3"
-  gem "sitemap_generator"
-  gem "meta-tags"
-  gem "sentry-ruby"
-  gem "sentry-rails"
-  gem "rack-attack"
-  gem "rdoc", require: false
-  gem "trenni-sanitize", require: false
-  gem "pastel", require: false
-  gem "rouge", require: false
-end
+gem "http"
+gem "typhoeus", require: false
+gem "kaminari", "~> 1.2.2"
+gem "inline_svg"
+gem "tty-spinner", require: false
+gem "skylight", group: :production
+gem "graphql"
+gem "graphiql-rails", group: :development
+gem "lograge"
+gem "logstash-event"
+gem "aws-sdk-s3"
+gem "sitemap_generator"
+gem "meta-tags"
+gem "sentry-ruby"
+gem "sentry-rails"
+gem "rack-attack"
+gem "rdoc", require: false
+gem "trenni-sanitize", require: false
+gem "pastel", require: false
+gem "rouge", require: false
+gem "rbs", require: false
+gem "stimulus_reflex", "= 3.5.0.pre9"
 
 gem "slim"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,6 +257,7 @@ GEM
       ast (~> 2.4.1)
     pastel (0.8.0)
       tty-color (~> 0.5)
+    pg (1.3.5)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -437,6 +438,7 @@ DEPENDENCIES
   logstash-event
   meta-tags
   pastel
+  pg
   propshaft
   puma
   rack-attack

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,26 +69,6 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    async (1.30.1)
-      console (~> 1.10)
-      nio4r (~> 2.3)
-      timers (~> 4.1)
-    async-container (0.16.12)
-      async
-      async-io
-    async-http (0.56.5)
-      async (>= 1.25)
-      async-io (>= 1.28)
-      async-pool (>= 0.2)
-      protocol-http (~> 0.22.0)
-      protocol-http1 (~> 0.14.0)
-      protocol-http2 (~> 0.14.0)
-    async-http-cache (0.4.2)
-      async-http (~> 0.56)
-    async-io (1.32.2)
-      async
-    async-pool (0.3.8)
-      async (>= 1.25)
     aws-eventstream (1.2.0)
     aws-partitions (1.587.0)
     aws-sdk-core (3.130.2)
@@ -108,9 +88,16 @@ GEM
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
-    build-environment (1.13.0)
     builder (3.2.4)
     byebug (11.1.3)
+    cable_ready (5.0.0.pre9)
+      actioncable (>= 5.2)
+      actionpack (>= 5.2)
+      actionview (>= 5.2)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
+      thread-local (>= 1.1.0)
     capybara (3.37.1)
       addressable
       matrix
@@ -122,8 +109,6 @@ GEM
       xpath (~> 3.2)
     childprocess (4.1.0)
     concurrent-ruby (1.1.10)
-    console (1.13.1)
-      fiber-local
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -157,18 +142,6 @@ GEM
     erubi (1.10.0)
     ethon (0.13.0)
       ffi (>= 1.15.0)
-    falcon (0.39.2)
-      async
-      async-container (~> 0.16.0)
-      async-http (~> 0.56.0)
-      async-http-cache (~> 0.4.0)
-      async-io (~> 1.22)
-      build-environment (~> 1.13)
-      bundler
-      localhost (~> 1.1)
-      process-metrics (~> 0.2.0)
-      rack (>= 1.0)
-      samovar (~> 2.1)
     faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -196,7 +169,6 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fiber-local (1.0.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     graphiql-rails (1.8.0)
@@ -240,7 +212,6 @@ GEM
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    localhost (1.1.8)
     lograge (0.12.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -252,7 +223,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mapping (1.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
     meta-tags (2.16.0)
@@ -287,24 +257,16 @@ GEM
       ast (~> 2.4.1)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    process-metrics (0.2.1)
-      console (~> 1.8)
-      samovar (~> 2.1)
     propshaft (0.6.4)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
       railties (>= 7.0.0)
-    protocol-hpack (1.4.2)
-    protocol-http (0.22.5)
-    protocol-http1 (0.14.1)
-      protocol-http (~> 0.22)
-    protocol-http2 (0.14.2)
-      protocol-hpack (~> 1.4)
-      protocol-http (~> 0.18)
     psych (4.0.3)
       stringio
     public_suffix (4.0.7)
+    puma (5.6.4)
+      nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
     rack-attack (6.6.1)
@@ -344,6 +306,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbs (2.3.2)
     rdoc (6.4.0)
       psych (>= 4.0.0)
     redis (4.6.0)
@@ -369,9 +332,6 @@ GEM
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    samovar (2.1.4)
-      console (~> 1.0)
-      mapping (~> 1.0)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -401,13 +361,23 @@ GEM
     standard (1.12.1)
       rubocop (= 1.29.1)
       rubocop-performance (= 1.13.3)
+    stimulus_reflex (3.5.0.pre9)
+      actioncable (>= 5.2)
+      actionpack (>= 5.2)
+      actionview (>= 5.2)
+      activesupport (>= 5.2)
+      cable_ready (>= 5.0.0.pre9)
+      nokogiri
+      rack
+      railties (>= 5.2)
+      redis
     stringio (3.0.1)
     strscan (3.0.2)
     temple (0.8.2)
     thor (1.2.1)
+    thread-local (1.1.0)
     tilt (2.0.10)
     timeout (0.2.0)
-    timers (4.3.3)
     trenni (3.13.1)
       rake-compiler
     trenni-sanitize (0.6.1)
@@ -455,7 +425,6 @@ DEPENDENCIES
   cssbundling-rails
   dotenv-rails
   elasticsearch-persistence
-  falcon
   graphiql-rails
   graphql
   hiredis
@@ -469,8 +438,10 @@ DEPENDENCIES
   meta-tags
   pastel
   propshaft
+  puma
   rack-attack
-  rails (~> 7.0.3)
+  rails (~> 7.0.2)
+  rbs
   rdoc
   redis (~> 4.6)
   rouge
@@ -481,6 +452,7 @@ DEPENDENCIES
   skylight
   slim
   standard
+  stimulus_reflex (= 3.5.0.pre9)
   trenni-sanitize
   tty-spinner
   typhoeus

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec falcon serve -b http://0.0.0.0:${PORT:-3000} --cache --preload config/preload.rb --count 2
+web: bundle exec rails server -p ${PORT:-3000}

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/app/javascript/controllers/app/application_controller.js
+++ b/app/javascript/controllers/app/application_controller.js
@@ -1,0 +1,60 @@
+import { Controller } from '@hotwired/stimulus'
+import StimulusReflex from 'stimulus_reflex'
+
+/* This is your ApplicationController.
+ * All StimulusReflex controllers should inherit from this class.
+ *
+ * Example:
+ *
+ *   import ApplicationController from './application_controller'
+ *
+ *   export default class extends ApplicationController { ... }
+ *
+ * Learn more at: https://docs.stimulusreflex.com
+ */
+export default class extends Controller {
+  connect () {
+    StimulusReflex.register(this)
+  }
+
+  /* Application-wide lifecycle methods
+   *
+   * Use these methods to handle lifecycle concerns for the entire application.
+   * Using the lifecycle is optional, so feel free to delete these stubs if you don't need them.
+   *
+   * Arguments:
+   *
+   *   element - the element that triggered the reflex
+   *             may be different than the Stimulus controller's this.element
+   *
+   *   reflex - the name of the reflex e.g. "Example#demo"
+   *
+   *   error/noop - the error message (for reflexError), otherwise null
+   *
+   *   reflexId - a UUID4 or developer-provided unique identifier for each Reflex
+   */
+
+  beforeReflex (element, reflex, noop, reflexId) {
+    // document.body.classList.add('wait')
+  }
+
+  reflexSuccess (element, reflex, noop, reflexId) {
+    // show success message
+  }
+
+  reflexError (element, reflex, error, reflexId) {
+    // show error message
+  }
+
+  reflexHalted (element, reflex, error, reflexId) {
+    // handle aborted Reflex action
+  }
+
+  afterReflex (element, reflex, noop, reflexId) {
+    // document.body.classList.remove('wait')
+  }
+
+  finalizeReflex (element, reflex, noop, reflexId) {
+    // all operations have completed, animation etc is now safe
+  }
+}

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,12 @@
 import { Application } from "@hotwired/stimulus"
+import StimulusReflex from 'stimulus_reflex'
 
 const application = Application.start()
 
 // Configure Stimulus development experience
 application.debug = false
 window.Stimulus   = application
+
+StimulusReflex.initialize(application, { isolate: true })
 
 export { application }

--- a/app/reflexes/application_reflex.rb
+++ b/app/reflexes/application_reflex.rb
@@ -1,0 +1,2 @@
+class ApplicationReflex < StimulusReflex::Reflex
+end

--- a/app/reflexes/ruby_object_reflex.rb
+++ b/app/reflexes/ruby_object_reflex.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class RubyObjectReflex < ApplicationReflex
+  # Add Reflex methods in this file.
+  #
+  # All Reflex instances include CableReady::Broadcaster and expose the following properties:
+  #
+  #   - connection  - the ActionCable connection
+  #   - channel     - the ActionCable channel
+  #   - request     - an ActionDispatch::Request proxy for the socket connection
+  #   - session     - the ActionDispatch::Session store for the current visitor
+  #   - flash       - the ActionDispatch::Flash::FlashHash for the current request
+  #   - url         - the URL of the page that triggered the reflex
+  #   - params      - parameters from the element's closest form (if any)
+  #   - element     - a Hash like object that represents the HTML element that triggered the reflex
+  #     - signed    - use a signed Global ID to map dataset attribute to a model eg. element.signed[:foo]
+  #     - unsigned  - use an unsigned Global ID to map dataset attribute to a model  eg. element.unsigned[:foo]
+  #   - cable_ready - a special cable_ready that can broadcast to the current visitor (no brackets needed)
+  #   - reflex_id   - a UUIDv4 that uniquely identies each Reflex
+  #   - tab_id      - a UUIDv4 that uniquely identifies the browser tab
+  #
+  # Example:
+  #
+  #   before_reflex do
+  #     # throw :abort # this will prevent the Reflex from continuing
+  #     # learn more about callbacks at https://docs.stimulusreflex.com/rtfm/lifecycle
+  #   end
+  #
+  #   def example(argument=true)
+  #     # Your logic here...
+  #     # Any declared instance variables will be made available to the Rails controller and view.
+  #   end
+  #
+  # Learn more at: https://docs.stimulusreflex.com/rtfm/reflex-classes
+
+  def toggle_signiture
+    @show_signitures = element[:checked]
+    session[:show_signitures] = @show_signitures
+  end
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,6 +14,7 @@ html lang="en"
 
     = csrf_meta_tags
     = csp_meta_tag
+    = action_cable_meta_tag
     = stylesheet_link_tag 'application'
     = javascript_include_tag 'essentials'
     = javascript_include_tag 'application', defer: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ require "action_controller/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require "action_view/railtie"
-# require "action_cable/engine"
+require "action_cable/engine"
 require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,7 @@ require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
 require "active_job/railtie"
-# require "active_record/railtie"
+require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
 # require "action_mailer/railtie"

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,10 @@
+development:
+  adapter: async
+
+test:
+  adapter: test
+
+production:
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: rubyapi_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,86 @@
+# PostgreSQL. Versions 9.3 and up are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem "pg"
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+development:
+  <<: *default
+  database: rubyapi_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user running Rails.
+  #username: rubyapi
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: rubyapi_test
+
+# As with config/credentials.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password or a full connection URL as an environment
+# variable when you boot the app. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# If the connection URL is provided in the special DATABASE_URL environment
+# variable, Rails will automatically merge its configuration values on top of
+# the values provided in this file. Alternatively, you can specify a connection
+# URL environment variable explicitly:
+#
+#   production:
+#     url: <%%= ENV["MY_APP_DATABASE_URL"] %>
+#
+# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full overview on how database connection configuration can be specified.
+#
+production:
+  <<: *default
+  database: rubyapi_production
+  username: rubyapi
+  password: <%%= ENV["RUBYAPI_DATABASE_PASSWORD"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: 127.0.0.1
   username: rubyapi
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,7 +19,8 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: rubyapi
 
 development:
   <<: *default
@@ -82,5 +83,4 @@ test:
 production:
   <<: *default
   database: rubyapi_production
-  username: rubyapi
-  password: <%%= ENV["RUBYAPI_DATABASE_PASSWORD"] %>
+  password: <%= ENV["RUBYAPI_DATABASE_PASSWORD"] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,6 +42,11 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  # Raise an error on page load if there are pending migrations.
+  config.active_record.migration_error = :page_load
+
+  # Highlight code that triggered database queries in logs.
+  config.active_record.verbose_query_logs = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/initializers/stimulus_reflex.rb
+++ b/config/initializers/stimulus_reflex.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# The ActionCable logger is REALLY noisy, and might even impact performance.
+# Uncomment the line below to silence the ActionCable logger.
+
+# ActionCable.server.config.logger = Logger.new(nil)
+
+StimulusReflex.configure do |config|
+  # Enable/disable exiting / warning when the sanity checks fail options:
+  # `:exit` or `:warn` or `:ignore`
+
+  config.on_failed_sanity_checks = :ignore if Rails.env.test?
+
+  # Enable/disable exiting / warning when there's a new StimulusReflex release
+  # `:exit` or `:warn` or `:ignore`
+
+  # config.on_new_version_available = :ignore
+
+  # Enable/disable exiting / warning when there is no default URLs specified in environment config
+  # `:warn` or `:ignore`
+
+  # config.on_missing_default_urls = :warn
+
+  # Override the parent class that the StimulusReflex ActionCable channel inherits from
+
+  # config.parent_channel = "ApplicationCable::Channel"
+
+  # Override the logger that the StimulusReflex uses; default is Rails' logger
+  # eg. Logger.new(RAILS_ROOT + "/log/reflex.log")
+
+  # config.logger = Rails.logger
+
+  # Customize server-side Reflex logging format, with optional colorization:
+  # Available tokens: session_id, session_id_full, reflex_info, operation, reflex_id, reflex_id_full, mode, selector, operation_counter, connection_id, connection_id_full, timestamp
+  # Available colors: red, green, yellow, blue, magenta, cyan, white
+  # You can also use attributes from your ActionCable Connection's identifiers that resolve to valid ActiveRecord models
+  # eg. if your connection is `identified_by :current_user` and your User model has an email attribute, you can access r.email (it will display `-` if the user isn't logged in)
+  # Learn more at: https://docs.stimulusreflex.com/appendices/troubleshooting#stimulusreflex-logging
+
+  # config.logging = proc { "[#{session_id}] #{operation_counter.magenta} #{reflex_info.green} -> #{selector.cyan} via #{mode} Morph (#{operation.yellow})" }
+
+  # Optimized for speed, StimulusReflex doesn't enable Rack middleware by default.
+  # If you are using Page Morphs and your app uses Rack middleware to rewrite part of the request path, you must enable those middleware modules in StimulusReflex.
+  #
+  # Learn more about registering Rack middleware in Rails here: https://guides.rubyonrails.org/rails_on_rack.html#configuring-middleware-stack
+
+  # config.middleware.use FirstRackMiddleware
+  # config.middleware.use SecondRackMiddleware
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,17 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
     depends_on:
       search:
         condition: service_healthy
+  cache:
+    image: redis:6.2-alpine
+    ports:
+    - "6379:6379"
   search:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,17 @@
 version: '3'
 services:
+  database:
+    image: postgres:14.3-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    healthcheck:
+      test: ["pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   kibana:
     image: docker.elastic.co/kibana/kibana:8.2.0
     ports:
@@ -13,10 +25,17 @@ services:
     depends_on:
       search:
         condition: service_healthy
+
   cache:
-    image: redis:6.2-alpine
+    image: redis:7-alpine
     ports:
     - "6379:6379"
+    healthcheck:
+      test: ["redis-cli ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   search:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "5432:5432"
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
+      - POSTGRES_USER=rubyapi
     healthcheck:
       test: ["pg_isready"]
       interval: 10s

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
+    "@rails/actioncable": "^7.0.2-4",
     "clipboard-copy": "^4.0.1",
     "esbuild": "^0.14.39",
     "hotkeys-js": "^3.9.3",
@@ -10,6 +11,8 @@
     "monaco-editor": "^0.33.0",
     "mustache": "^4.2.0",
     "postcss": "^8.4.14",
+    "stimulus-dropdown": "^2.0.0",
+    "stimulus_reflex": "^3.5.0-pre9",
     "tailwindcss": "^3.0.24"
   },
   "devDependencies": {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,9 @@ Dir.glob(Rails.root.join("lib/*.rb")).each { |f| require_relative f }
 WebMock.disable!
 
 class ActiveSupport::TestCase
+  # Run tests in parallel with specified workers
+  parallelize(workers: :number_of_processors)
+
   # Add more helper methods to be used by all tests here...
   def create_index_for_version!(version)
     search_repository(version).create_index! force: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@hotwired/stimulus@^3.0.1":
+"@hotwired/stimulus@>= 3.0", "@hotwired/stimulus@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
   integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
@@ -27,6 +27,16 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@rails/actioncable@>= 6.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2.tgz#69a6d999f4087e0537dd38fe0963db1f4305d650"
+  integrity sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA==
+
+"@rails/actioncable@^7.0.2-4":
+  version "7.0.2-4"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2-4.tgz#24a31bde761ee7652b2567d267699c17c7e725a6"
+  integrity sha512-EPTZ0U/KBlaJKPAyLuvPBSZMojyHVgCqwMDkwTfm4TDPyp5f0hTBsOsolQxqeOJmoTafK+7pJi7hO9eCjBEhTA==
 
 acorn-node@^1.6.1:
   version "1.8.2"
@@ -71,6 +81,13 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+"cable_ready@>= 5.0.0-pre9":
+  version "5.0.0-pre9"
+  resolved "https://registry.yarnpkg.com/cable_ready/-/cable_ready-5.0.0-pre9.tgz#9c082b796f7b7add7965ce637a8d8717726be5ab"
+  integrity sha512-m7XggG+LRPFLsbH78G603F3AAYpkv+VfGCouN6RrP20Mgz9H0+xr7v2DN2F1CeJBBAliYPKcAt/48uTGjSrBaA==
+  dependencies:
+    morphdom "^2.6.1"
 
 camelcase-css@^2.0.1:
   version "2.0.1"
@@ -313,7 +330,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hotkeys-js@^3.9.3:
+hotkeys-js@>=3, hotkeys-js@^3.9.3:
   version "3.9.3"
   resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.9.3.tgz#4b755cc695b388d7f93a83aff4b0c2a45719996c"
   integrity sha512-s+f0xyvDmf6+DyrFQ2SY+eA7lbvMbjqkqi0I0SpMgnN5tZx7DeH8nsWhkJR4KEq3pxDPHJppDUhdt1rZFW5LeQ==
@@ -381,6 +398,11 @@ monaco-editor@^0.33.0:
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.33.0.tgz#842e244f3750a2482f8a29c676b5684e75ff34af"
   integrity sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==
+
+morphdom@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/morphdom/-/morphdom-2.6.1.tgz#e868e24f989fa3183004b159aed643e628b4306e"
+  integrity sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA==
 
 mustache@^4.2.0:
   version "4.2.0"
@@ -503,6 +525,29 @@ source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+stimulus-dropdown@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stimulus-dropdown/-/stimulus-dropdown-2.0.0.tgz#3d401e418be21787f182c0de4bf0d2fd91cfbf8e"
+  integrity sha512-3VUZ4TI9qHvzw+sOEX1oQA8Pw8C/K5yI+oltr5B9DTwFzuJrFZRWR33OK3ERllzZep+quvHZZljIpIRifKCmCg==
+  dependencies:
+    stimulus-use "^0.50.0-2"
+
+stimulus-use@^0.50.0-2:
+  version "0.50.0-2"
+  resolved "https://registry.yarnpkg.com/stimulus-use/-/stimulus-use-0.50.0-2.tgz#7b019fa7618133f42b41bb5d4275fe2e92649819"
+  integrity sha512-vnYifIYeiRe2J0PlQ34mYHdOkLB7HVF55RdDErgOBkgHBAqC05vEIwt3xNuyayuhT5YboVmV0eJCfRN1sxumKg==
+  dependencies:
+    hotkeys-js ">=3"
+
+stimulus_reflex@^3.5.0-pre9:
+  version "3.5.0-pre9"
+  resolved "https://registry.yarnpkg.com/stimulus_reflex/-/stimulus_reflex-3.5.0-pre9.tgz#e99eaf11e9e7476df10cd8f5c557d368f54446b3"
+  integrity sha512-ZhGUuJaKaWhHU5eGnZQ3pgnv0/pJ4dtNABDtMZRAHNm3ngsHY5dpR/H801a1ozD6J5rpadONvhhBcPjPY/x6NQ==
+  dependencies:
+    "@hotwired/stimulus" ">= 3.0"
+    "@rails/actioncable" ">= 6.0"
+    cable_ready ">= 5.0.0-pre9"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is some pre-emptive work to add [Stimulus Reflex](https://docs.stimulusreflex.com/) to that i wish to use as part of work that adds a toggle to switch between showing method type signatures and the documented method signatures (current) on the show object page. Stimulus Reflex isn't doing anything at the moment besides just being loaded in the background.

Note: I was having issues with Falcon and Stimulus Reflex, not sure if they're compatible or if there is a bug with websockets present.  I've switched to Puma for this PR and will investigate further.