### PR TITLE
Type Signatures

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,8 @@
       "label": "app: start",
       "dependsOn": [
         "rails: server",
-        "rails: webpack-dev-server"
+        "yarn: build:watch",
+        "yarn: build:css:watch"
       ],
       "problemMatcher": []
     },
@@ -25,9 +26,25 @@
       "command": "./bin/rails server"
     },
     {
-      "label": "rails: webpack-dev-server",
+      "label": "yarn: build",
       "type": "shell",
-      "command": "./bin/webpack-dev-server"
+      "command": "./bin/yarn build"
+    },
+    {
+      "label": "yarn: build:watch",
+      "type": "shell",
+      "command": "./bin/yarn build --watch"
+    },
+    {
+      "label": "yarn: build:css",
+      "type": "shell",
+
+      "command": "./bin/yarn build:css"
+    },
+    {
+      "label": "yarn: build:css:watch",
+      "type": "shell",
+      "command": "./bin/yarn build:css --watch"
     },
     {
       "label": "rake: import:ruby",

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem "pastel", require: false
 gem "rouge", require: false
 gem "rbs", require: false
 gem "stimulus_reflex", "= 3.5.0.pre9"
+gem "rbs"
 
 gem "slim"
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,12 +45,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :home_path
 
-  def skip_session
-    request.session_options[:skip] = true
+  def enable_public_cache
+    expires_in 24.hours, public: true
   end
 
-  def enable_public_cache
-    skip_session
-    expires_in 24.hours, public: true
+  def enable_private_cache
+    expires_in 24.hours, public: false
   end
 end

--- a/app/controllers/objects_controller.rb
+++ b/app/controllers/objects_controller.rb
@@ -3,9 +3,11 @@
 class ObjectsController < ApplicationController
   rescue_from Elasticsearch::Persistence::Repository::DocumentNotFound, with: -> { raise ActionController::RoutingError.new("Not Found") }
 
-  before_action :enable_public_cache
+  before_action :set_cache
 
   def show
+    session[:show_signatures] ||= false
+    @show_signatures = session[:show_signatures]
     @object = object_repository.find(document_id)
   end
 
@@ -14,6 +16,14 @@ class ObjectsController < ApplicationController
   end
 
   private
+
+  def set_cache
+    signatures_enabled? ? enable_private_cache : enable_public_cache
+  end
+
+  def signatures_enabled?
+    !!session[:show_signatures]
+  end
 
   def object_repository
     @repository ||= RubyObjectRepository.repository_for_version(ruby_version)

--- a/app/models/ruby_method.rb
+++ b/app/models/ruby_method.rb
@@ -23,6 +23,10 @@ class RubyMethod
     body[:object_constant]
   end
 
+  def signitures
+    body[:signitures]
+  end
+
   def class_method?
     method_type == "class_method"
   end
@@ -104,7 +108,8 @@ class RubyMethod
       call_sequence: call_sequence,
       alias: method_alias,
       source_body: source_body,
-      metadata: metadata
+      metadata: metadata,
+      signitures: signitures
     }
   end
 

--- a/app/models/ruby_version.rb
+++ b/app/models/ruby_version.rb
@@ -29,4 +29,8 @@ class RubyVersion
   def dev?
     @version == "dev"
   end
+
+  def has_type_signitures?
+    @version >= "3.0" || dev?
+  end
 end

--- a/app/reflexes/ruby_object_reflex.rb
+++ b/app/reflexes/ruby_object_reflex.rb
@@ -33,8 +33,8 @@ class RubyObjectReflex < ApplicationReflex
   #
   # Learn more at: https://docs.stimulusreflex.com/rtfm/reflex-classes
 
-  def toggle_signiture
-    @show_signitures = element[:checked]
-    session[:show_signitures] = @show_signitures
+  def toggle_signatures
+    current = ActiveRecord::Type::Boolean.new.cast(session[:show_signatures])
+    @show_signatures = session[:show_signatures] = !current
   end
 end

--- a/app/views/objects/_sidebar.html.slim
+++ b/app/views/objects/_sidebar.html.slim
@@ -40,6 +40,14 @@
 div class="hidden lg:block w-1/4"
   div class="hidden lg:block lg:sticky pt-1 top-0"
     div class="overflow-y-auto mt-24 pl-3 pr-6 h-93"
+      div class="mb-3"
+        div class="flex items-center space-x-2 px-2 overflow-visible"
+          h3 class="font-bold text-gray-700 dark:text-gray-200" Type Signatures
+          span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800" Preview
+        div class="px-2 py-1 text-sm" id="signatures-description"
+          | Show type signitures generated automatically by <a href="https://github.com/ruby/rbs" target="_blank" class="text-blue-600">RBS</a>.
+        div class="px-2 py-1"
+          button type="button" data-reflex="click->RubyObject#toggle_signatures" class="inline-flex items-center px-3 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm leading-4 font-medium rounded-md bg-white hover:bg-gray-50 dark:bg-gray-700 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600 dark:focus:ring-gray-900"= @show_signatures ? "Disable Type Signatures" : "Enable Type Signatures"
       - if @object.superclass
         = render "objects/sidebar/section", title: 'Parent' do
           = render "objects/sidebar/section/link",

--- a/app/views/objects/show/_methods.html.slim
+++ b/app/views/objects/show/_methods.html.slim
@@ -9,9 +9,16 @@ div class="relative"
     a style="display: block; position: relative; top: -80px; visibility: hidden;" id="#{method_anchor m}"
     div class="flex flex-wrap"
       div class="w-full md:w-10/12"
-        a href="##{method_anchor(m)}"
-          - m.call_sequence.each do |seq|
-            h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= seq
+        - if @show_signatures && m.signitures.any?
+          a href="##{method_anchor(m)}"
+            h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= m.name
+          div class="py-2"
+            - m.signitures.each do |sig|
+              h4 class="font-mono leading-tight text-gray-900 dark:text-gray-200"= sig
+        - else
+          a href="##{method_anchor(m)}"
+            - m.call_sequence.each do |seq|
+              h4 class="lg:text-2xl text-lg text-gray-900 dark:text-gray-200 font-semibold"= seq
 
       div class="flex md:justify-end w-full md:w-2/12 mt-3 md:mt-0 font-mono"
         span class="px-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 algin-middle cursor-default" title="#{m.method_type.capitalize} Method"

--- a/app/views/objects/sidebar/_section.html.slim
+++ b/app/views/objects/sidebar/_section.html.slim
@@ -1,4 +1,4 @@
 div class="mb-3"
-  h3 class="font-bold text-gray-700 dark:text-gray-200 p-1 px-2"
-    | #{title}
+  - if title.present?
+    h3 class="font-bold text-gray-700 dark:text-gray-200 p-1 px-2"= title
   = yield

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,9 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis_cache_store, 
+      url: ENV.fetch("REDIS_CACHE_URL") { "redis://localhost:6379/1" }
+
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
@@ -60,4 +62,8 @@ Rails.application.configure do
   # Site doesn't have a login, so the CSRF protection isn't helpful
   # In fact, it's problematic because the varying CSRF tokens means you can't get a consistent ETag
   config.action_controller.allow_forgery_protection = false
+
+  config.session_store :cache_store, key: "_sessions_development",
+    compress: true, pool_size: 5, expire_after: 1.month
+    url: ENV.fetch("REDIS_SESSION_URL") { "redis://localhost:6380/1" } 
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,8 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
+  config.cache_store = :redis_cache_store, 
+    url: ENV.fetch("REDIS_CACHE_URL") { "redis://localhost:6379/1" }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
@@ -87,4 +88,8 @@ Rails.application.configure do
 
   # Disable CSRF protections
   config.action_controller.allow_forgery_protection = false
+
+  config.session_store :cache_store, key: "_sessions_production",
+    compress: true, pool_size: 5, expire_after: 1.month
+    url: ENV.fetch("REDIS_SESSION_URL") { "redis://localhost:6380/1" }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,18 @@ services:
       timeout: 5s
       retries: 5
 
+  session:
+    image: redis:7-alpine
+    command:
+    - "--maxmemory-policy noeviction"
+    ports:
+    - "6380:6380"
+    healthcheck:
+      test: ["redis-cli ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   search:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0
     ports:

--- a/lib/ruby_downloader.rb
+++ b/lib/ruby_downloader.rb
@@ -22,7 +22,7 @@ class RubyDownloader
     end
 
     fetch_ruby_archive
-    unpack
+    prepare_environment
   end
 
   def rubies_download_path
@@ -58,8 +58,9 @@ class RubyDownloader
     File.exist? extracted_download_path.join "README.md"
   end
 
-  def unpack
+  def prepare_environment
     system "unzip #{download_path} -d #{rubies_download_path} > #{File::NULL}"
+    system "gem unpack --target #{extracted_download_path.join("gems")} #{extracted_download_path.join("gems/rbs-*.gem")}" if release.has_type_signitures?
   end
 
   def setup_paths

--- a/lib/ruby_type_signiture_repository.rb
+++ b/lib/ruby_type_signiture_repository.rb
@@ -1,0 +1,70 @@
+require "rbs"
+
+class RubyTypeSignitureRepository
+  STDLIB_PATH = "stdlib"
+  CORE_PATH = "core"
+  RUBY_SRC_GEMS_FOLDER = "gems"
+
+  def initialize(ruby_src_dir)
+    @ruby_dir = Pathname(ruby_src_dir)
+    init_rbs_environment
+  end
+
+  def signiture_for_object_instance_method(object:, method:)
+    rbs_type_for_object(object) do |object_type|
+      return lookup_type_method_signiture(object_type, method, method_type: :instance)
+    end
+  end
+
+  def signiture_for_object_class_method(object:, method:)
+    rbs_type_for_object(object) do |object_type|
+      return lookup_type_method_signiture(object_type, method, method_type: :class)
+    end
+  end
+
+  private
+
+  def rbs_type_for_object(klass, &block)
+    type = RBS::TypeName.new(name: klass.to_sym, namespace: RBS::Namespace.root)
+    yield type if block_given?
+    type
+  end
+
+  def lookup_type_method_signiture(type, method, method_type:)
+    case method_type.to_sym
+    when :instance
+      method_definition_for_context(@builder.build_instance(type), method)
+    when :class
+      method_definition_for_context(@builder.build_singleton(type), method)
+    else
+      nil
+    end
+  rescue RuntimeError => e
+    return nil
+  end
+
+  def init_rbs_environment
+    @loader = RBS::EnvironmentLoader.new(core_root: rbs_gem_path.join(CORE_PATH))
+    repository.gems.keys.each { |lib| @loader.add library: lib }
+
+    @environment = RBS::Environment.from_loader(@loader).resolve_type_names
+    @builder = RBS::DefinitionBuilder.new(env: @environment)
+  end
+
+  def method_definition_for_context(context, method)
+    context.methods[method.to_sym]&.method_types
+  rescue RuntimeError => e
+    return nil if e.message =~ /unknown name/
+    raise
+  end
+
+  def repository
+    @repository ||= RBS::Repository.new(no_stdlib: true).tap do |r|
+      r.add(rbs_gem_path.join("stdlib"))
+    end
+  end
+
+  def rbs_gem_path
+    @rbs_path ||= Pathname(Dir.glob("#{@ruby_dir.join(RUBY_SRC_GEMS_FOLDER)}/rbs-*").find { |f| Pathname(f).directory? })
+  end
+end


### PR DESCRIPTION
This PR adds a new feature to import the type signatures of the ruby-src, using the RBS gem and allows the user can optionally toggle that on the Ruby Object page.