### PR TITLE
Move Ruby Version config to anyway_config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ yarn-debug.log*
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+/config/*.local.yml
+/config/credentials/local.*

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "pastel", require: false
 gem "rouge", require: false
 gem "rbs", require: false
 gem "stimulus_reflex", "= 3.5.0.pre9"
-
+gem "anyway_config"
 gem "slim"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    anyway_config (2.3.0)
+      ruby-next-core (>= 0.14.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.587.0)
@@ -330,6 +332,7 @@ GEM
     rubocop-performance (1.13.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
+    ruby-next-core (0.15.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -421,6 +424,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  anyway_config
   aws-sdk-s3
   bootsnap (>= 1.1.0)
   byebug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,12 @@
 
 class ApplicationController < ActionController::Base
   def ruby_version
-    params[:version] || Rails.configuration.default_ruby_version
+    params[:version] || default_ruby_version
   end
   helper_method :ruby_version
 
   def default_ruby_version
-    Rails.configuration.default_ruby_version
+    RubyConfig.default_ruby_version.version
   end
   helper_method :default_ruby_version
 
@@ -17,15 +17,12 @@ class ApplicationController < ActionController::Base
   helper_method :search_query
 
   def supported_ruby_versions
-    ruby_versions = Rails.configuration.ruby_versions.dup
-    other_versions = eol_ruby_versions.dup.push(ruby_version)
-
-    ruby_versions - other_versions
+    RubyConfig.active_ruby_versions.map(&:version)
   end
   helper_method :supported_ruby_versions
 
   def eol_ruby_versions
-    Rails.configuration.eol_ruby_versions
+    RubyConfig.eol_ruby_versions.map(&:version)
   end
   helper_method :eol_ruby_versions
 
@@ -40,7 +37,7 @@ class ApplicationController < ActionController::Base
   helper_method :route_for_version
 
   def home_path
-    return root_path if Rails.configuration.default_ruby_version == ruby_version
+    return root_path if RubyConfig.default_ruby_version.version == ruby_version
     versioned_root_path(version: ruby_version)
   end
   helper_method :home_path

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,18 +4,18 @@ module Types
   class QueryType < Types::BaseObject
     field :rubyObject, Types::RubyObjectType, null: true, method: :ruby_object do
       argument :constant, String, required: true, description: "Ruby Object constant"
-      argument :version, String, required: false, default_value: Rails.configuration.default_ruby_version
+      argument :version, String, required: false, default_value: RubyConfig.default_ruby_version.version
     end
 
     field :search, [Types::SearchResultType], null: true, method: :search do
       argument :query, String, required: true
-      argument :version, String, required: false, default_value: Rails.configuration.default_ruby_version
+      argument :version, String, required: false, default_value: RubyConfig.default_ruby_version.version
       argument :page, Integer, required: false, default_value: 1
     end
 
     field :autocomplete, [Types::AutocompleteSearchResultType], null: true, method: :autocomplete do
       argument :query, String, required: true
-      argument :version, String, required: false, default_value: Rails.configuration.default_ruby_version
+      argument :version, String, required: false, default_value: RubyConfig.default_ruby_version.version
     end
 
     def ruby_object(constant:, version:)

--- a/app/models/ruby_version.rb
+++ b/app/models/ruby_version.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class RubyVersion
-  attr_accessor :version, :sha512, :source_url
+  attr_accessor :version, :sha512, :source_url, :default, :eol
 
-  def initialize(version, sha512: nil, source_url: nil)
+  alias_method :default?, :default
+  alias_method :eol?, :eol
+
+  def initialize(version, sha512: nil, source_url: nil, default: false, eol: false)
     unless version == "dev"
       raise ArgumentError, "invalid version #{version.inspect}" unless Gem::Version.correct?(version)
       @_version = Gem::Version.new(version)
@@ -13,6 +16,8 @@ class RubyVersion
     @version = version
     @sha512 = sha512
     @source_url = URI(source_url) if source_url.present?
+    @default = default
+    @eol = eol
   end
 
   def minor_version

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,15 +35,6 @@ module RubyApi
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    # default ruby version documentation
-    config.default_ruby_version = '3.1'
-
-    config.ruby_versions = %w[
-      3.1 3.0 2.7 2.6 2.5 2.4 2.3 dev
-    ]
-
-    config.eol_ruby_versions = %w[2.5 2.4 2.3]
-
     config.elasticsearch_shards = ENV.fetch('ELASTICSEARCH_SHARDS', 5).to_i
     config.elasticsearch_replicas = ENV.fetch('ELASTICSEARCH_REPLICAS', 1).to_i
     config.repl_host = ENV.fetch('REPL_HOST', '')

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,10 @@ Bundler.require(*Rails.groups)
 
 module RubyApi
   class Application < Rails::Application
+    # Configure the path for configuration classes that should be used before initialization
+    # NOTE: path should be relative to the project root (Rails.root)
+    # config.anyway_config.autoload_static_config_path = "config/configs"
+    #
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 

--- a/config/configs/application_config.rb
+++ b/config/configs/application_config.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Base class for application config classes
+class ApplicationConfig < Anyway::Config
+  class << self
+    # Make it possible to access a singleton config instance
+    # via class methods (i.e., without explicitly calling `instance`)
+    delegate_missing_to :instance
+
+    private
+
+    # Returns a singleton config instance
+    def instance
+      @instance ||= new
+    end
+  end
+end

--- a/config/configs/ruby_config.rb
+++ b/config/configs/ruby_config.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class RubyConfig < ApplicationConfig
+  attr_config :versions
+  coerce_types versions: {type: nil, array: true}
+
+  on_load :ensure_default_version
+
+  def ruby_versions
+    @ruby_versions ||= build_ruby_versions
+  end
+
+  def default_ruby_version
+    @default_ruby_version ||= ruby_versions.find(&:default?)
+  end
+
+  def active_ruby_versions
+    @active_ruby_versions ||= ruby_versions.reject(&:eol?)
+  end
+
+  def eol_ruby_versions
+    @eol_ruby_verisons ||= ruby_versions.select(&:eol?)
+  end
+
+  private
+
+  def ensure_default_version
+    raise "Missing default Ruby Version, see ruby.yml" unless ruby_versions.any?(&:default?)
+  end
+
+  def build_ruby_versions
+    versions.map do |v|
+      raise "Missing Ruby Version" unless v[:version].present?
+
+      RubyVersion.new(
+        v[:version].to_s,
+        default: v[:default],
+        eol: v[:eol]
+      )
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   get '/ping', to: 'healthcheck#index'
   get '/repl', to: 'repl#index'
 
-  ruby_versions = Rails.configuration.ruby_versions.collect { |v| Regexp.escape(v) }
+  ruby_versions = RubyConfig.ruby_versions.collect { |v| Regexp.escape(v.version) }
 
   scope "(:version)", constraints: { version: /#{ruby_versions.join("|")}/ } do
     root to: "home#index", as: :versioned_root

--- a/config/ruby.yml
+++ b/config/ruby.yml
@@ -1,0 +1,23 @@
+default: &default
+  versions:
+    - version: 3.1
+      default: true
+    - version: 3.0
+    - version: 2.7
+    - version: 2.6
+    - version: 2.5
+      eol: true
+    - version: 2.4
+      eol: true
+    - version: 2.3
+      eol: true
+    - version: dev
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -6,7 +6,7 @@ require_relative "../ruby_documentation_importer"
 namespace :import do
   desc "import Ruby documentation for given version"
   task :ruby, [:version] => :environment do |t, args|
-    args.with_defaults version: Rails.configuration.default_ruby_version
+    args.with_defaults version: RubyConfig.default_ruby_version.version
 
     release = RubyReleases::ReleaseList.fetch.find { |r| r.version.to_s == args.version }
 

--- a/test/models/ruby_version_test.rb
+++ b/test/models/ruby_version_test.rb
@@ -15,18 +15,22 @@ class RubyVersionTest < ActiveSupport::TestCase
   end
 
   test "#prerelease?" do
-    version = RubyVersion.new("2.7.0-preview3")
-    assert_equal version.prerelease?, true
-
-    version = RubyVersion.new("2.7.0")
-    assert_equal version.prerelease?, false
+    assert RubyVersion.new("2.7.0-preview3").prerelease?
+    refute RubyVersion.new("2.7.0").prerelease?
   end
 
   test "#dev?" do
-    version = RubyVersion.new("dev")
-    assert_equal version.dev?, true
+    assert RubyVersion.new("dev").dev?
+    refute RubyVersion.new("2.4.0").dev?
+  end
 
-    version = RubyVersion.new("2.4.0")
-    assert_equal version.dev?, false
+  test "eol?" do
+    refute RubyVersion.new("3.1", eol: false).eol?
+    assert RubyVersion.new("2.4.0", eol: true).eol?
+  end
+
+  test "default?" do
+    refute RubyVersion.new("3.1", default: false).default?
+    assert RubyVersion.new("3.1", default: true).default?
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,7 @@ class ActiveSupport::TestCase
   end
 
   def default_ruby_version
-    Rails.configuration.default_ruby_version
+    RubyConfig.default_ruby_version.version
   end
 
   def index_search(object, version: nil)


### PR DESCRIPTION
The current ruby configuration is a painpoint. We have to maintain different configuration options to indicate with versions of Ruby are EOL, which version is the "default", and perform calculations to know which set is currently being maintained by the core team.

This PR introduces the gem [anyway_config](https://github.com/palkan/anyway_config) that moves this configuration into a single YML file that we can compile into a RubyVersion that we easily filter and lookup. 