### PR TITLE
Change default ports for Redis, PostgreSQL and ElasticSearch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      
+
       - name: Run linting
         run: ./bin/standardrb --no-fix
 
@@ -51,7 +51,7 @@ jobs:
       cache:
         image: redis:7-alpine
         ports:
-          - "6379:6379"
+          - "6381:6381"
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -60,7 +60,7 @@ jobs:
       database:
         image: postgres:14.3-alpine
         ports:
-          - "5432:5432"
+          - "5433:5433"
         env:
           "POSTGRES_HOST_AUTH_METHOD": "trust"
           "POSTGRES_USER": "rubyapi"
@@ -103,7 +103,7 @@ jobs:
       cache:
         image: redis:7-alpine
         ports:
-          - "6379:6379"
+          - "6381:6381"
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -112,7 +112,7 @@ jobs:
       database:
         image: postgres:14.3-alpine
         ports:
-          - "5432:5432"
+          - "5433:5433"
         env:
           "POSTGRES_HOST_AUTH_METHOD": "trust"
           "POSTGRES_USER": "rubyapi"

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,7 +6,7 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_SESSION_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDIS_SESSION_URL") { "redis://localhost:6381/1" } %>
   channel_prefix: rubyapi_production
   ssl_params:
     verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -41,9 +41,9 @@ development:
   # domain sockets, so uncomment these lines.
   #host: localhost
 
-  # The TCP port the server listens on. Defaults to 5432.
+  # The TCP port the server listens on. Defaults to 5433.
   # If your server runs on a different port number, change accordingly.
-  #port: 5432
+  port: 5433
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :redis_cache_store, {
-      url: ENV.fetch("REDIS_CACHE_URL") { "redis://localhost:6379/1" }
+      url: ENV.fetch("REDIS_CACHE_URL") { "redis://localhost:6381/1" }
     }
 
     config.public_file_server.headers = {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   config.cache_store = :redis_cache_store, {
-    url: ENV.fetch("REDIS_CACHE_URL") { "redis://localhost:6379/1" },
+    url: ENV.fetch("REDIS_CACHE_URL") { "redis://localhost:6381/1" },
     ssl_params: {
       verify_mode: OpenSSL::SSL::VERIFY_NONE
     }
@@ -101,7 +101,7 @@ Rails.application.configure do
       pool_size: 5,
       expire_after: 1.month,
       url: ENV.fetch("REDIS_SESSION_URL") { "redis://localhost:6380/1" },
-      ssl_params: { 
+      ssl_params: {
         verify_mode: OpenSSL::SSL::VERIFY_NONE
       }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   database:
     image: postgres:14.3-alpine
     ports:
-      - "5432:5432"
+      - "5433:5433"
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_USER=rubyapi
@@ -30,7 +30,7 @@ services:
   cache:
     image: redis:7-alpine
     ports:
-    - "6379:6379"
+    - "6381:6381"
     healthcheck:
       test: ["redis-cli ping"]
       interval: 10s


### PR DESCRIPTION
They already can be run in background, so `docker compose up` can fail.