### PR TITLE
Replace byebug with debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem "slim"
 gem "redis-session-store"
 
 group :development, :test do
-  gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "debug"
   gem "dotenv-rails"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,6 @@ GEM
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.37.1)
       addressable
       matrix
@@ -108,6 +107,9 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.1.1)
       railties (>= 6.0.0)
+    debug (1.6.1)
+      irb (>= 1.3.6)
+      reline (>= 0.3.1)
     digest (3.1.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -184,6 +186,9 @@ GEM
     inline_svg (1.8.0)
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jmespath (1.6.1)
     jsbundling-rails (1.0.3)
       railties (>= 6.0.0)
@@ -308,6 +313,8 @@ GEM
       actionpack (>= 3, < 8)
       redis (>= 3, < 5)
     regexp_parser (2.4.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.5)
@@ -410,9 +417,9 @@ DEPENDENCIES
   anyway_config
   aws-sdk-s3
   bootsnap (>= 1.1.0)
-  byebug
   capybara (>= 2.15)
   cssbundling-rails
+  debug
   dotenv-rails
   elasticsearch-persistence
   graphiql-rails


### PR DESCRIPTION
This PR aligns Ruby API with the Rails and Ruby communities moving to the https://github.com/ruby/debug gem for debugging functionality in Ruby 3