### PR TITLE
Fix dev import

### DIFF
--- a/lib/ruby_downloader.rb
+++ b/lib/ruby_downloader.rb
@@ -15,7 +15,10 @@ class RubyDownloader
   def download
     setup_paths
 
-    if already_fetched?
+    if release.dev?
+      # Don't cache dev, since it changes frequently
+      extracted_download_path.rmtree if extracted_download_path.exist?
+    elsif already_fetched?
       puts "Found previously extracted download for " \
         "#{release.version}, skipping"
       return


### PR DESCRIPTION
- Download the .gem files for ruby-master. The cache.ruby-lang.org stable release zips include the .gem files for each bundled gem, but the github master branch .zip does not. Download any missing .gem files from RubyGems.
- Skip cache for dev, since it changes daily. Prevent "do you want to overwrite file x" prompts by just recursively deleting the folder for dev.

Fixes #1189 