### PR TITLE
Autocomplete Controller

### DIFF
--- a/app/components/header/search_component.html.erb
+++ b/app/components/header/search_component.html.erb
@@ -1,4 +1,4 @@
-<div class="relative" data-controller="search" data-search-version="<%= @ruby_version %>" data-search-url="<%= graphql_path %>">
+<div class="relative" data-controller="search" data-search-version="<%= @ruby_version %>" data-search-url="<%= autocomplete_url(version: @ruby_version) %>">
   <%= form_tag(search_url(version: @ruby_version), method: :get, class: "m-0") do %>
     <div class="relative">
       <button type="submit" class="block absolute left inset-y-0 px-4 #{'text-gray-700 fill-current' if homepage?}" aria-label="search">

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AutocompleteController < ApplicationController
+  before_action :enable_public_cache
+
+  def index
+    search_results = Search::Autocomplete.search(search_query, version: ruby_version).first(5)
+    render json: search_results.map { |r| AutocompleteResult.new(r, version: ruby_version) }
+  end
+
+  def search_query
+    params[:q] || ""
+  end
+end

--- a/app/javascript/controllers/app/search_controller.js
+++ b/app/javascript/controllers/app/search_controller.js
@@ -123,26 +123,19 @@ export default class extends Controller {
   async autocomplete(query, version, path) {
     this.suggestionIndex = 0
 
-    fetch(path, {
-      method: "post",
+    const queryParam = new URLSearchParams({q: query})
+    const url = `${path}?${queryParam.toString()}`
+
+    fetch(url , {
+      method: "get",
       headers: {
         'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        query: `
-        query GetAutocompleteResults($query: String!, $version: String = "2.6") {
-          autocomplete(query: $query, version: $version) {
-            text
-            path
-          }
-        }`,
-        variables: { query, version }
-      })
+      }
     })
       .then((response) => { return response.json() })
       .then((results) => {
         const render = mustache.render(this.autocompleteTemplate, {
-          results: results.data.autocomplete
+          results: results
         })
         this.autocompleteTarget.innerHTML = render
       })

--- a/app/models/autocomplete_result.rb
+++ b/app/models/autocomplete_result.rb
@@ -17,4 +17,11 @@ class AutocompleteResult
   def path
     result_url result, version:
   end
+
+  def to_hash
+    {
+      text: autocomplete,
+      path: path
+    }
+  end
 end

--- a/app/repositories/search_repository.rb
+++ b/app/repositories/search_repository.rb
@@ -87,11 +87,11 @@ class SearchRepository
     klass_for_document(document).new(document[:_source])
   end
 
-  def bulk_import(records)
+  def bulk_import(records, wait_for_refresh: false)
     records.each_slice(500) do |slice|
       entries = slice.each_with_object([]) { |o, arr| arr.push(o.to_hash, *o.ruby_methods.map(&:to_hash)) }
       payload = entries.flat_map { |o| [{index: {}}, o.to_hash] }
-      client.bulk(body: payload, index: index_name)
+      client.bulk(body: payload, index: index_name, refresh: wait_for_refresh)
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     get "o/s", to: "search#index", as: :search
     post "o/toggle_signatures", to: "objects#toggle_signatures", as: :toggle_signatures
     get "o/*object", to: "objects#show", as: :object
+    get "a", to: "autocomplete#index", as: :autocomplete, default: {format: :json}
 
     post "/run", to: "code_execute#post"
   end

--- a/test/controllers/autocomplete_controller_test.rb
+++ b/test/controllers/autocomplete_controller_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AutocompleteControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    create_index_for_version! default_ruby_version
+
+    objects = [String, Array, Integer, Symbol, Hash].map { |klass| ruby_object(klass) }
+    bulk_index_search objects, version: default_ruby_version, wait_for_refresh: true
+  end
+
+  test "should get index" do
+    get autocomplete_path(q: "new")
+    assert_response :success
+  end
+
+  test "should render results" do
+    get autocomplete_path(q: "to_i")
+    assert_equal 5, response.parsed_body.length
+  end
+
+  test "should cache responses" do
+    get autocomplete_path(q: "view")
+    assert_equal response.headers["Cache-Control"], "max-age=86400, public"
+  end
+
+  test "should render empty array when no query is given" do
+    get autocomplete_path(q: "")
+    assert_equal [], response.parsed_body
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,10 @@ class ActiveSupport::TestCase
     RubyConfig.default_ruby_version.version
   end
 
+  def bulk_index_search(objects, version: nil, wait_for_refresh: false)
+    search_repository(version).bulk_import(objects, wait_for_refresh: wait_for_refresh)
+  end
+
   def index_search(object, version: nil)
     search_repository(version).save object
   end


### PR DESCRIPTION
This PR moves the autocomplete API from the GraphQL API - which i am looking to remove in #1225 - to just a normal rails that responds in mostly the same way.