### PR TITLE
Fix styling for ordered lists

### DIFF
--- a/app/assets/css/application.css
+++ b/app/assets/css/application.css
@@ -70,6 +70,7 @@ pre:not(.ruby) {
 
 .ruby-documentation ul { @apply pl-4; }
 .ruby-documentation ul li { @apply list-disc; }
+.ruby-documentation ol li { @apply list-decimal; }
 .ruby-documentation dd, .ruby-documentation dt { @apply w-full text-center; }
 .ruby-documentation dl { @apply flex flex-wrap border-2 border-gray-400; }
 .ruby-documentation dd { @apply px-3; }


### PR DESCRIPTION
Without this change, ordered lists inside documentation will have the `list-style: none` property which causes them to be displayed improperly. We're already overriding the style for unordered lists on the line above so let's do the same for ordered lists.

Fixes #1249