### PR TITLE
Ruby release Git Tag & branches information

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,13 +12,9 @@ module ApplicationHelper
   def github_url(ruby_doc)
     version, file, line = ruby_doc.source_location.split(":")
 
-    if Current.ruby_version.dev?
-      # Not using URI.join, for a performance optimization. URI.join does A LOT of allocations.
-      # We know that our source_location is safe, because we make it in the importer.
-      # Inspiration: https://github.com/rack/rack/pull/1202
-      %(#{GITHUB_REPO}/master/#{file}#{"#L#{line}" if line})
-    else
-      %(#{GITHUB_REPO}/v#{version.tr(".", "_")}/#{file}#{"#L#{line}" if line})
-    end
+    # Not using URI.join, for a performance optimization. URI.join does A LOT of allocations.
+    # We know that our source_location is safe, because we make it in the importer.
+    # Inspiration: https://github.com/rack/rack/pull/1202
+    %(#{GITHUB_REPO}/#{Current.ruby_version.git_ref}/#{file}#{"#L#{line}" if line})
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
 
   # Map a method source file into a url to Github.com
   def github_url(ruby_doc)
-    version, file, line = ruby_doc.source_location.split(":")
+    _version, file, line = ruby_doc.source_location.split(":")
 
     # Not using URI.join, for a performance optimization. URI.join does A LOT of allocations.
     # We know that our source_location is safe, because we make it in the importer.

--- a/app/models/ruby_version.rb
+++ b/app/models/ruby_version.rb
@@ -4,6 +4,7 @@ class RubyVersion < Dry::Struct
   attribute :version, Types::String
   attribute :url, Types::String
   attribute :sha256, Types::String
+  attribute :git, Types::Hash.default({}.freeze) # Git repository information
 
   attribute :default, Types::Bool.default(false) # The latest stable version of Ruby
   attribute :eol, Types::Bool.default(false) # Versions of Ruby that have reached end-of-life
@@ -27,6 +28,18 @@ class RubyVersion < Dry::Struct
 
   def prerelease?
     dev? || prerelease
+  end
+
+  def git_ref
+    git_tag.present? ? git_tag : git_branch
+  end
+
+  def git_branch
+    git[:branch]
+  end
+
+  def git_tag
+    git[:tag]
   end
 
   def dev?

--- a/app/models/ruby_version.rb
+++ b/app/models/ruby_version.rb
@@ -31,7 +31,7 @@ class RubyVersion < Dry::Struct
   end
 
   def git_ref
-    git_tag.present? ? git_tag : git_branch
+    git_tag.presence || git_branch
   end
 
   def git_branch

--- a/config/configs/ruby_config.rb
+++ b/config/configs/ruby_config.rb
@@ -34,7 +34,8 @@ class RubyConfig < ApplicationConfig
         sha256: v[:sha256] || "",
         default: v[:default] || false,
         eol: v[:eol] || false,
-        prerelease: v[:prerelease] || false
+        prerelease: v[:prerelease] || false,
+        git: v[:git] || {}
       )
     end
   end

--- a/config/ruby.yml
+++ b/config/ruby.yml
@@ -4,33 +4,59 @@ default: &default
       default: true
       sha256: cca9ddbc958431ff77f61948cb67afa569f01f99c9389d2bbedfa92986c9ef09
       url: https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.0.zip
+      git:
+        tag: v3_2_0
+        branch: ruby_3_2
     - version: 3.1
       sha256: 9e5de00a1d259a2c6947605825ecf6742d5216bd389af28f9ed366854e59b09e
       url: https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.3.zip
+      git:
+        tag: v3_1_3
+        branch: ruby_3_1
     - version: 3.0
       sha256: 4b63c59ebdc0abcea139a561d67dfa9770af2d9619390f34b8a53f9625a1090d
       url: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.zip
+      git:
+        tag: v3_0_5
+        branch: ruby_3_0
     - version: 2.7
       url: https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.6.zip
       sha256: 2ead329cfb9a5975348d2fdcfa0cb60bb3ba47a6693e93afd52db7a0ba01ac4c
+      git:
+        tag: v2_7_6
+        branch: ruby_2_7
     - version: 2.6
       url: https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.10.zip
       sha256: 381e62de1cbac80b356c2fa77ee1906a169bb8cde4a9ec64541a41db32db046d
+      git:
+        tag: v2_6_10
+        branch: ruby_2_6
     - version: 2.5
       url: https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.9.zip
       sha256: 14db683c6ba6a863ef126718269758de537571b675231ec43f03b987739e3ce1
       eol: true
+      git:
+        tag: v2_5_9
+        branch: ruby_2_5
     - version: 2.4
       url: https://cache.ruby-lang.org/pub/ruby/2.4/ruby-2.4.10.zip
       sha256: 3babcf264a22b52951974ed4c5232c3fe14f2ada72daad47bf8b73639a7eec50
       eol: true
+      git:
+        tag: v2_4_10
+        branch: ruby_2_4
     - version: 2.3
       url: https://cache.ruby-lang.org/pub/ruby/2.3/ruby-2.3.8.zip
       sha256: ec9792d0473a22954ad25cd0c531fc672679c1a5eaeefa08caf9e1288852796f
       eol: true
+      git:
+        tag: v2_3_8
+        branch: ruby_2_3
     - version: dev
       url: https://github.com/ruby/ruby/archive/master.zip
       sha256:
+      git:
+        branch: master
 
 development:
   <<: *default

--- a/test/factories/ruby_versions.rb
+++ b/test/factories/ruby_versions.rb
@@ -7,6 +7,13 @@ FactoryBot.define do
     sha256 { "61843112389f02b735428b53bb64cf988ad9fb81858b8248e22e57336f24a83e" }
     default { false }
 
+    git do
+      {
+        branch: "ruby_3_1",
+        tag: "v3_1_0"
+      }
+    end
+
     trait :default do
       default { true }
     end
@@ -15,6 +22,12 @@ FactoryBot.define do
       version { "dev" }
       url { "https://github.com/ruby/ruby/archive/master.zip" }
       sha256 { "" }
+      git do
+        {
+          branch: "master",
+          tag: ""
+        }
+      end
     end
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,7 +2,20 @@
 
 class ApplicationHelperTest < ActionView::TestCase
   test "github_url" do
-    method = FactoryBot.build(:ruby_method, source_location: "2.6.4:string.c:3")
-    assert_equal github_url(method), "https://github.com/ruby/ruby/blob/v2_6_4/string.c#L3"
+    ruby_version = FactoryBot.build(:ruby_version)
+    method = FactoryBot.build(:ruby_method, source_location: "3.1.0:string.c:3")
+
+    Current.ruby_version = ruby_version
+
+    assert_equal github_url(method), "https://github.com/ruby/ruby/blob/v3_1_0/string.c#L3"
+  end
+
+  test "github_url for ruby dev" do
+    ruby_version = FactoryBot.build(:ruby_version, :dev)
+    method = FactoryBot.build(:ruby_method, source_location: "dev:string.c:3")
+
+    Current.ruby_version = ruby_version
+
+    assert_equal github_url(method), "https://github.com/ruby/ruby/blob/master/string.c#L3"
   end
 end

--- a/test/models/ruby_version_test.rb
+++ b/test/models/ruby_version_test.rb
@@ -47,6 +47,24 @@ class RubyVersionTest < ActiveSupport::TestCase
     assert ruby_version.prerelease?
   end
 
+  test "git ref" do
+    ruby_version = FactoryBot.build(:ruby_version, git: {branch: "master"})
+    assert_equal "master", ruby_version.git_ref
+
+    ruby_version = FactoryBot.build(:ruby_version, git: {tag: "v1.0"})
+    assert_equal "v1.0", ruby_version.git_ref
+  end
+
+  test "git branch" do
+    ruby_version = FactoryBot.build(:ruby_version, git: {branch: "master"})
+    assert_equal "master", ruby_version.git_branch
+  end
+
+  test "git tag" do
+    ruby_version = FactoryBot.build(:ruby_version, git: {tag: "v1.0"})
+    assert_equal "v1.0", ruby_version.git_tag
+  end
+
   test "to string" do
     ruby_version = FactoryBot.build(:ruby_version, version: "3.1")
     assert_equal "3.1", ruby_version.to_s


### PR DESCRIPTION
This PR adds Git branch & tag information to the Ruby config to allow us to correctly build links and references to ruby-src code on GitHub.com.

Closes #1359