### PR TITLE
Add podman as docker alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Start ElasticSearch:
 ```sh
 docker compose up -d
 ```
+or if you are using podman:
+
+```sh
+podman-compose up -d
+```
 
 Start the Rails Server
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,16 @@ Start ElasticSearch:
 ```sh
 docker compose up -d
 ```
-or if you are using podman:
+
+<details>
+<summary>Alternatives to Docker</summary>
+
+We only officially support Docker, but you can try with [Podman](https://podman.io) instead:
 
 ```sh
 podman-compose up -d
 ```
+</details>
 
 Start the Rails Server
 


### PR DESCRIPTION
Due to changes in Docker's licensing, many companies no longer allow it to be used, but podman is a drop-in replacement in most cases.

(I had initially tried `podman compose` instead of `podman-compose`, so hopefully this will save someone else a little time).