### PR TITLE
Add Github Action to build image and deploy to Github Packages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pack command
+        uses: buildpacks/github-actions/setup-pack@v5.0.0
+
+      - name: Build application image
+        run: pack build rubyapi --path . --builder heroku/builder:22 --tag ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Inspect application image
+        run: pack inspect-image rubyapi
+
+      - name: Push Image
+        run: docker push ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,4 @@
+name: Deploy
 on:
   workflow_run:
     workflows: ["CI"]

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,14 @@
 name: Deploy
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows:
       - Test
     types:
       - completed
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 name: Deploy
+
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows:
+      - Test
     types:
       - completed
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,22 @@
+[_]
+id = "rubyapi/rubyapi"
+name = "Ruby API"
+version = "1.0.0"
+
+[[io.buildpacks.build.env]]
+name = "RAILS_ENV"
+value = "production"
+
+[[io.buildpacks.build.env]]
+name = "NODE_ENV"
+value = "production"
+
+[[io.buildpacks.group]]
+uri = "urn:cnb:registry:heroku/nodejs"
+
+[[io.buildpacks.group]]
+uri = "urn:cnb:registry:heroku/nodejs-npm"
+
+[[io.buildpacks.group]]
+uri = "urn:cnb:registry:heroku/ruby"
+


### PR DESCRIPTION
Ruby API is slowly being migrated away from Heroku to AWS. I'm most likely going to use ECS to run the application. To begin building up the infrastructure, i need a Docker image of the application i can pull into ECS.

Native Buildpacks is a cool tool that allows you to build images using the same buildpacks used in Heroku. This vastly simplifies our build process and removes the need for a complex Dockerfile.