### PR TITLE
Fix command typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ bin/dev
 Ruby's documentation can be imported very easily. There's a rake task that will let you import a given versions' documentation:
 
 ```sh
-bin/rails import:ruby[3.1]
+bin/rake import:ruby[3.1]
 ```
 
 or you can easily import the latest versions of all currently supported versions of ruby:
 
 ```sh
-bin/rails import:ruby:all
+bin/rake import:ruby:all
 ```
 
 ## Running tests


### PR DESCRIPTION
The import task is to be
run via `bin/rake`, not via
`bin/rails`.