### PR TITLE
Fix duplicate path fragments from PathCleaner.clean

### DIFF
--- a/app/services/path_cleaner.rb
+++ b/app/services/path_cleaner.rb
@@ -5,7 +5,7 @@ module PathCleaner
     uri.path.delete_suffix(".html").split("/").each do |path_part|
       if path_part == ".."
         class_parts.pop
-      else
+      elsif !class_parts.include?(path_part)
         class_parts.push(path_part)
       end
     end

--- a/test/services/path_cleaner_test.rb
+++ b/test/services/path_cleaner_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PathCleanerTest < ActiveSupport::TestCase
+  test "clean relative uris with constant" do
+    assert_object_param "fiber", PathCleaner.clean(make_uri("../Fiber"), constant: "Fiber::SchedulerInterface", version: "1.0")
+    assert_object_param(
+      "rubyvm/abstractsyntaxtree",
+      PathCleaner.clean(make_uri("../AbstractSyntaxTree"), constant: "RubyVM::AbstractSyntaxTree::Node", version: "1.0")
+    )
+  end
+
+  test "clean path full path with nested constant" do
+    assert_object_param(
+      "thread/queue",
+      PathCleaner.clean(make_uri("Thread/Queue"), constant: "Thread::Queue", version: "1.0")
+    )
+    assert_object_param(
+      "csv/row",
+      PathCleaner.clean(make_uri("CSV/Row"), constant: "CSV::Row", version: "1.0")
+    )
+  end
+
+  test "clean path partial path with nested constant" do
+    assert_object_param(
+      "rubyvm/abstractsyntaxtree/node",
+      PathCleaner.clean(make_uri("Node"), constant: "RubyVM::AbstractSyntaxTree::Node", version: "1.0")
+    )
+  end
+
+  test "clean path with unrelated constant" do
+    assert_object_param(
+      "enumerator/arithmeticsequence",
+      PathCleaner.clean(make_uri("Enumerator/Arithmeticsequence"), constant: "String", version: "1.0")
+    )
+
+    assert_object_param(
+      "io",
+      PathCleaner.clean(make_uri("../IO"), constant: "Fiber::SchedulerInterface", version: "1.0")
+    )
+  end
+
+  private
+
+  def assert_object_param(expected, uri_string)
+    uri = URI(uri_string)
+    assert_equal expected, uri.path.split("/")[3..].join("/")
+  end
+
+  def make_uri(path)
+    URI("#{path}.html")
+  end
+end


### PR DESCRIPTION
The PathCleaner generates path fragments according to the ruby constants. This works by splitting the uri path provided by ruby into class parts. When handling nested constants, the default class part list contains all constant fragments from the constant name except the last one.

We need to do this because the ruby docs sometimes do not include the parent class parts in the uri path. However sometimes they do include those parent class parts.

This led to class parts being duplicated in the cleaned path. One example of this is `Thread::Queue#deq`. The alias method path provided by ruby is "Thread/Queue" and the constant is "Thread::Queue". When cleaning the path we default to `['Thread']` and join "Thread" and "Queue" afterwards, resulting in the path `thread/thread/queue` which is not valid.

This patch tries to fix this by only adding new class parts if the new part does not already exist in the list of class parts.

Fixes #1748