### PR TITLE
fix import:ruby:all task

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -26,7 +26,7 @@ namespace :import do
 
   namespace :ruby do
     task all: :environment do
-      RubyRelease.each do |version|
+      RubyRelease.find_each do |version|
         RubyDocumentationImporter.import version
       end
     end


### PR DESCRIPTION
Fix undefined method `each` error in `import:ruby:all` task

While running the `import:ruby:all` task, I encountered: **NoMethodError: undefined method 'each' for class RubyRelease**


The issue is on line 29 of `lib/tasks/import.rake` where `RubyRelease.each` is called directly on the class instead of on a collection of records.

**Fix:** Changed `RubyRelease.each` to `RubyRelease.find_each` to properly iterate over all RubyRelease records.