### PR TITLE
fix: add back tailwindcss:watch to bin/dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,2 +1,16 @@
-#!/usr/bin/env ruby
-exec "./bin/rails", "server", *ARGV
+#!/usr/bin/env sh
+
+if ! gem list foreman -i --silent; then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
+# Let the debug gem allow remote connections,
+# but avoid loading until `debugger` is called
+export RUBY_DEBUG_OPEN="true"
+export RUBY_DEBUG_LAZY="true"
+
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
I noticed that the `tailwindcss:watch` process doesn’t start with `bin/dev`.

It seems the `bin/dev` script was modified in commit 52293c15ae059d033ea7c49ffb7983ea83c633aa possibly overridden during the Rails 8 upgrade via `rails app:update`.