### PR TITLE
fix ruby-documentation li style

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -133,8 +133,12 @@ pre:not(.ruby) {
     @apply list-disc list-inside;
 }
 
+.ruby-documentation ul li {
+    @apply my-1;
+}
+
 .ruby-documentation ul li p {
-    @apply inline-block my-1;
+    @apply inline;
 }
 
 .ruby-documentation ol {


### PR DESCRIPTION
Some list items `<li>`  are rendered with their content starting on a new line instead of appearing inline. This happens in many places such as

- [Kernel#Complex](https://rubyapi.org/3.4/o/kernel#method-i-Complex)

- [Kernel#exec](https://rubyapi.org/3.4/o/kernel#method-i-exec)

- [Kernel#require](https://rubyapi.org/3.4/o/kernel#method-i-require)

This PR fixes the CSS so that list item contents are displayed on the same line as their bullet.