### PR TITLE
fix render description for alias instance methods

### DIFF
--- a/app/views/objects/show/_methods.html.erb
+++ b/app/views/objects/show/_methods.html.erb
@@ -119,15 +119,17 @@
       </div>
 
       <div class="ruby-documentation py-1">
+        <% if m.description.empty? %>
+          <div>No documentation available</div>
+        <% else %>
+          <%= raw m.description %>
+        <% end %>
+
         <% if m.is_alias? %>
           <div>
             An alias for
             <a href="<%= m.method_alias[:path] %>" class="font-bold"><%= m.method_alias[:name] %></a>
           </div>
-        <% elsif m.description.empty? %>
-          <div>No documentation available</div>
-        <% else %>
-          <%= raw m.description %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
I've noticed that descriptions for alias instance methods are not rendered. For example:

- [String#size](https://rubyapi.org/3.4/o/string#method-i-size)

- [String#next](https://rubyapi.org/3.4/o/string#method-i-next)

- [String#to_sym](https://rubyapi.org/3.4/o/string#method-i-to_sym)

- [Kernel#fail](https://rubyapi.org/3.4/o/kernel#method-i-fail)

- [Kernel#format](https://rubyapi.org/3.4/o/kernel#method-i-format)

...and many other alias methods.

This issue comes from the following condition in the methods partial:
```ruby
# app/views/objects/show/_methods.html.erb
<% if m.is_alias? %>
  <div>An alias for <a href="<%= m.method_alias[:path] %>" class="font-bold"><%= m.method_alias[:name] %></a></div>
<% elsif m.description.empty? %>
  <div>No documentation available</div>
<% else %>
   <%= raw m.description %>
<% end %>
``` 
Because of this, if a method is an alias, its own description is skipped even when the API data actually contains documentation for that alias.

This PR updates the rendering logic so that alias methods can also display their descriptions (when present).
### **Edit:**
After opening the PR, I noticed that this behavior differs depending on the documentation source.
For example, [ruby-doc.org](https://ruby-doc.org/3.4.1/Kernel.html#method-i-fail) includes the description for alias methods, while [docs.ruby-lang.org](https://docs.ruby-lang.org/en/3.4/Kernel.html#method-i-fail) does not show the description for aliases. This suggests it may be a deliberate design choice upstream?

However, showing the description on alias methods could still provide a more complete and helpful documentation experience?