### PR TITLE
Add documentation for Ruby 4.0

### DIFF
--- a/config/ruby.yml
+++ b/config/ruby.yml
@@ -1,5 +1,13 @@
 default: &default
   versions:
+    - version: 4.0
+      default: true
+      sha256: 70cb1bf89279b86ab9a975d504607c051fc05ee03e311d550a5541b65e373455
+      url: https://cache.ruby-lang.org/pub/ruby/4.0/ruby-4.0.0.zip
+      signatures: true
+      git:
+        tag: v4.0.0
+        branch: ruby_4_0
     - version: 3.5
       default: false
       sha256: 3e1d9df578c69976a01a69b961819d00c4e8942f8b5fe4fb8e135fca4f7e7e5e
@@ -8,10 +16,8 @@ default: &default
       prerelease: true
       git:
         tag: v3_5_0_preview1
-        branch: master
-
     - version: 3.4
-      default: true
+      default: false
       sha256: a0c62089fb75c47e392bc96778dd76bd7ad1baa40a7ed040372c805de20bccc8
       url: https://cache.ruby-lang.org/pub/ruby/3.4/ruby-3.4.1.zip
       signatures: true


### PR DESCRIPTION
Add Ruby 4.0 documentation and set as default

Since Ruby 4.0 has been released, this PR:
- Adds documentation for Ruby 4.0
- Sets 4.0 as the default version