### PR TITLE
Fix: Remove duplicate search box on versioned homepage

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   GITHUB_REPO = "https://github.com/ruby/ruby/blob"
 
   def homepage?
-    current_page?(root_path) || current_page?(versioned_root_path(release: Current.ruby_release.version))
+    current_page?(root_path) || current_page?(versioned_root_path(version: Current.ruby_release.version))
   end
 
   # Map a method source file into a url to Github.com


### PR DESCRIPTION
I've noticed that when switching between Ruby versions on the homepage, an extra search box appears.

<img width="1343" height="389" alt="Screenshot from 2026-01-07 11-50-03" src="https://github.com/user-attachments/assets/f588dd61-320a-4ce6-b29f-ffd2f8de1942" />

The issue occurs in the `_header` partial
```erb
  <% unless homepage? %>
    <div class="flex-auto md:max-w-lg"><%= render "layouts/search" %></div>
  <% end %>
```
The `homepage?` helper returns false for `versioned_root_path` because `release` is passed as a scope parameter, not `version`. This causes the search box to render on the versioned homepage when it shouldn't.