### PR TITLE
Fix canonical link url

### DIFF
--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -1,5 +1,5 @@
 <% title @object.constant %>
-<% set_meta_tags canonical: object_url(object: @object.path, version: Current.default_ruby_release) unless Current.ruby_release.default? %>
+<% set_meta_tags canonical: object_url(object: @object.path, version: Current.default_ruby_release.version) unless Current.ruby_release.default? %>
 
 <% content_for :mobile_menu do %>
   <nav class="sticky">

--- a/test/controllers/objects_controller_test.rb
+++ b/test/controllers/objects_controller_test.rb
@@ -27,6 +27,15 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "canonical link to latest version" do
+    legacy_version = ruby_releases(:legacy)
+    @string.update(documentable: legacy_version)
+
+    get object_url object: @string.path, version: legacy_version.version
+
+    assert_select 'link[rel=canonical][href*="/3.4/o/string"]'
+  end
+
   test "object not found on different ruby version" do
     get object_url object: "/o/invalid-object", version: ruby_releases(:legacy).version
 


### PR DESCRIPTION
The canonical URL was being generated with a `RubyRelease` id instead of its `version`. This resulted in incorrect canonical links, `https://rubyapi.org/1/o/string` instead of `https://rubyapi.org/4.0/o/string`

<img width="656" height="141" alt="Screen Shot 2026-04-13 at 5 11 15 AM" src="https://github.com/user-attachments/assets/38a2836f-8d3a-400c-8c53-6139e54d86b5" />

The fix is to pass the actual version value:
```rb
version: Current.default_ruby_release.version
```

Alternatively, [`to_param`](https://api.rubyonrails.org/classes/ActiveRecord/Integration.html#method-i-to_param) method could be defined in the model to return the `version`.

