### PR TITLE
Fix duplicated "Included Modules" header

### DIFF
--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -148,15 +148,15 @@
         <% end %>
 
         <% unless @object.included_modules.empty? %>
-          <% @object.included_modules.each do |included_module| %>
-            <div class="mb-3">
-              <h3 class="font-bold text-gray-700 dark:text-gray-200 p-1 px-2">
-                Included Modules
-              </h3>
+          <div class="mb-3">
+            <h3 class="font-bold text-gray-700 dark:text-gray-200 p-1 px-2">
+              Included Modules
+            </h3>
 
+            <% @object.included_modules.each do |included_module| %>
               <%= link_to included_module.constant, object_path(object: included_module.path), class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 font-mono text-sm" %>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         <% end %>
 
         <% unless @object.ruby_constants.empty? %>


### PR DESCRIPTION
Move "Included Modules" header outside of the `@object.included_modules.each` loop.

Example: https://rubyapi.org/4.0/o/stringio

| Before | After |
|--------|--------|
| <img width="299" height="223" alt="Screenshot from 2026-04-13 22-18-55" src="https://github.com/user-attachments/assets/a5d3b63e-3199-432a-8f4a-eb0955788fa9" /> | <img width="299" height="223" alt="Screenshot from 2026-04-13 22-19-03" src="https://github.com/user-attachments/assets/253ee49f-4165-4749-ac97-76178813ffe3" /> | 