### PR TITLE
Fix missing class/module label

### DIFF
--- a/app/models/ruby_object.rb
+++ b/app/models/ruby_object.rb
@@ -73,11 +73,11 @@ class RubyObject < ApplicationRecord
   end
 
   def class_object?
-    object_type == "class"
+    object_type == "class_object"
   end
 
   def module_object?
-    object_type == "module"
+    object_type == "module_object"
   end
 
   def depth

--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -241,7 +241,7 @@
           </h1>
         </div>
 
-        <div class="mt-4 flex md:ml-4 md:mt-0">
+        <div class="mt-4 flex md:ml-4 md:mt-0" id="object-type-label">
           <% if @object.class_object? %>
             <span class="py-1 px-2 rounded bg-gray-200 dark:bg-gray-700 text-sm">
               Class

--- a/test/controllers/objects_controller_test.rb
+++ b/test/controllers/objects_controller_test.rb
@@ -33,6 +33,14 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "show object type (class/module)" do
+    get object_url object: @string.path
+    assert_select "#object-type-label", "Class"
+
+    get object_url object: ruby_objects(:enumerable).path
+    assert_select "#object-type-label", "Module"
+  end
+
   test "show method sequence" do
     get object_url object: @string.path
 

--- a/test/fixtures/ruby_objects.yml
+++ b/test/fixtures/ruby_objects.yml
@@ -9,7 +9,7 @@ string:
   name: String
   path: string
   description: Class for manipulating strings of characters.
-  object_type: class
+  object_type: class_object
   constant: String
   superclass_constant: Object
 
@@ -18,7 +18,7 @@ integer:
   name: Integer
   path: integer
   description: Class for manipulating integer numbers.
-  object_type: class
+  object_type: class_object
   constant: Integer
   superclass_constant: Numeric
 
@@ -27,7 +27,7 @@ enumerable:
   name: Enumerable
   path: enumerable
   description: Module providing collection traversal and searching methods.
-  object_type: module
+  object_type: module_object
   constant: Enumerable
 
 net_http:
@@ -35,5 +35,5 @@ net_http:
   name: HTTP
   path: net/http
   description: Class Net::HTTP provides a rich library that implements the client in a client-server model that uses the HTTP request-response protocol.
-  object_type: class
+  object_type: class_object
   constant: Net::HTTP

--- a/test/models/ruby_object_test.rb
+++ b/test/models/ruby_object_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class RubyObjectTest < ActiveSupport::TestCase
   test "object types" do
-    class_object = RubyObject.new(object_type: "class")
-    module_object = RubyObject.new(object_type: "module")
+    class_object = ruby_objects(:string)
+    module_object = ruby_objects(:enumerable)
 
     assert class_object.class_object?
     refute class_object.module_object?


### PR DESCRIPTION
Fix predicate checks for `object_type`: https://github.com/rubyapi/rubyapi/blob/06052ae72281be05a4065b97cd87e10a5cc210cc/app/models/ruby_object.rb#L75-L81 to match stored values (`"class_object"`, `"module_object"`): https://github.com/rubyapi/rubyapi/blob/06052ae72281be05a4065b97cd87e10a5cc210cc/lib/rubyapi_rdoc_generator.rb#L96

Update fixtures and add a test for label rendering.

Before  <img width="960" height="65" alt="Screenshot from 2026-04-14 20-47-45" src="https://github.com/user-attachments/assets/5cfefbe0-f59a-45d6-9e0c-653a236b2399" />
After  <img width="960" height="65" alt="Screenshot from 2026-04-14 20-47-52" src="https://github.com/user-attachments/assets/4cd7829b-b780-48ea-9f26-582698e7f805" />

Fixes #2395