### PR TITLE
Update link styles to improve link visibility

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -178,3 +178,13 @@ pre:not(.ruby) {
 .ruby-documentation h5 {
     @apply font-semibold text-lg py-1;
 }
+
+.ruby-documentation a {
+  @apply underline;
+  @variant hover {
+    @apply text-gray-500 dark:text-white;
+    & code {
+      @apply text-inherit;
+    }
+  }
+}


### PR DESCRIPTION
Plain links in `.ruby-documentation` are hard to distinguish from surrounding text, and links wrapping `<code>` can look identical to non-linked code. This makes it not obvious what is clickable. 

| Before | After |
|--------|--------|
| <img width="401" height="385" alt="Screenshot from 2026-04-21 19-34-35" src="https://github.com/user-attachments/assets/db11d6cc-8e7d-4d8d-b289-13f4754bc683" />  |  <img width="401" height="385" alt="Screenshot from 2026-04-21 19-34-53" src="https://github.com/user-attachments/assets/2f5495e7-57f2-4349-afe0-48e51c462b6a" /> |
|  <img width="1266" height="794" alt="Screenshot from 2026-04-21 19-02-57" src="https://github.com/user-attachments/assets/6af0f5c9-c374-42e2-9648-c6f47e8ab9ca" /> | <img width="1266" height="794" alt="Screenshot from 2026-04-21 19-02-41" src="https://github.com/user-attachments/assets/ca9035c4-5505-40f9-99a4-4ce9fc26ff53" /> |