### PR TITLE
Run dev tailwindcss through Puma

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,1 @@
 web: bundle exec rails server -p 3000
-css: bin/rails tailwindcss:watch

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -38,6 +38,7 @@ plugin :statsd
 
 # Enable Solid Queue integration with Puma
 plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"] || Rails.env.development?
+plugin :tailwindcss if ENV["TAILWINDCSS_IN_PUMA"] || Rails.env.development?
 
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.


### PR DESCRIPTION
Moves the tailwindcss watcher out of Procfile.dev and into Puma as a plugin, mirroring how solid_queue is already configured. One fewer process to run in development, and bin/dev now boots a single web process that handles its own CSS rebuilds.

Enabled by default in development. Outside of development, set TAILWINDCSS_IN_PUMA=1 to opt in.