### PR TITLE
Remove Procfiles

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: HTTP_PORT=$PORT TARGET_PORT=3001 bundle exec thrust bin/rails server

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,0 @@
-web: bundle exec rails server -p 3000

--- a/bin/dev
+++ b/bin/dev
@@ -1,16 +1,2 @@
-#!/usr/bin/env sh
-
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
-# Default to port 3000 if not specified
-export PORT="${PORT:-3000}"
-
-# Let the debug gem allow remote connections,
-# but avoid loading until `debugger` is called
-export RUBY_DEBUG_OPEN="true"
-export RUBY_DEBUG_LAZY="true"
-
-exec foreman start -f Procfile.dev "$@"
+#!/usr/bin/env ruby
+exec "./bin/rails", "server", *ARGV


### PR DESCRIPTION
With tailwindcss now running through Puma, we can run all required processes for development from a single `rails server` command. 

This PR removes the Procfile and updates `bin/dev` to match the current rails template - https://github.com/rails/rails/blob/a9c083078a2e72029fdedafa24232850dcc3de0b/railties/lib/rails/generators/rails/app/templates/bin/dev.tt#L1