### PR TITLE
Set default opensearch user/password for development/test environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,15 +49,14 @@ jobs:
           - 9200:9200
         env:
           "discovery.type": "single-node"
-          "plugins.security.disabled": "true"
         options: >-
-          --health-cmd "curl --silent --fail http://localhost:9200/_cluster/health || exit 1"
+          --health-cmd "curl -u admin:admin --silent --fail --insecure https://localhost:9200/_cluster/health || exit 1"
           --health-start-period 30s
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
     env:
-      SEARCH_URL: "http://localhost:9200"
+      OPENSEARCH_URL: "https://admin:admin@localhost:9200"
       DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test"
       QUEUE_DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test_queue"
       RAILS_ENV: test
@@ -100,15 +99,14 @@ jobs:
           - 9200:9200
         env:
           "discovery.type": "single-node"
-          "plugins.security.disabled": "true"
         options: >-
-          --health-cmd "curl --silent --fail http://localhost:9200/_cluster/health || exit 1"
+          --health-cmd "curl -u admin:admin --silent --fail --insecure https://localhost:9200/_cluster/health || exit 1"
           --health-start-period 30s
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
     env:
-      SEARCH_URL: "http://localhost:9200"
+      OPENSEARCH_URL: "https://admin:admin@localhost:9200"
       DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test"
       QUEUE_DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test_queue"
       RAILS_ENV: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      OPENSEARCH_URL: "https://admin:admin@localhost:9200"
       DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test"
       QUEUE_DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test_queue"
       RAILS_ENV: test
@@ -106,7 +105,6 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      OPENSEARCH_URL: "https://admin:admin@localhost:9200"
       DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test"
       QUEUE_DATABASE_URL: "postgresql://rubyapi:rubyapi_password@localhost:5432/rubyapi_test_queue"
       RAILS_ENV: test

--- a/config/opensearch.yml
+++ b/config/opensearch.yml
@@ -1,5 +1,5 @@
 development:
-  url: http://localhost:9200
+  url: https://admin:admin@localhost:9200
 
 test:
-  url: http://localhost:9200
+  url: https://admin:admin@localhost:9200


### PR DESCRIPTION
A follow up to #2398 that sets the default user/password for OpenSearch in development & testing.