### PR TITLE
Fix search results for constants not scrolling

### DIFF
--- a/app/views/objects/show.html.erb
+++ b/app/views/objects/show.html.erb
@@ -34,7 +34,7 @@
         <ul class="font-mono text-sm">
           <% @object.ruby_constants.each do |constant| %>
             <li>
-              <%= link_to constant.name, "##{constant.name}", class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" %>
+              <%= link_to constant.name, "##{constant_anchor(constant)}", class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" %>
             </li>
           <% end %>
         </ul>
@@ -168,7 +168,7 @@
             <ul class="font-mono text-sm">
               <% @object.ruby_constants.ordered.each do |constant| %>
                 <li>
-                  <%= link_to constant.name, "##{constant.name}", class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" %>
+                  <%= link_to constant.name, "##{constant_anchor(constant)}", class: "inline-block w-full py-1 px-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700" %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/objects/show/_constants.html.erb
+++ b/app/views/objects/show/_constants.html.erb
@@ -13,7 +13,7 @@
 
   <% constants.each do |c| %>
     <div class="md:p-3 py-3 my-3">
-      <div class="block relative invisible -top-24" id="<%= c.name %>"></div>
+      <div class="block relative invisible -top-24" id="<%= constant_anchor(c) %>"></div>
 
       <div class="flex flex-wrap">
         <div class="w-full md:w-10/12">
@@ -23,7 +23,7 @@
               font-semibold
             "
           >
-            <a href="#<%= c.name %>"><%= c.name %></a>
+            <a href="#<%= constant_anchor(c) %>"><%= c.name %></a>
           </h4>
         </div>
       </div>

--- a/test/controllers/autocomplete_controller_test.rb
+++ b/test/controllers/autocomplete_controller_test.rb
@@ -22,4 +22,12 @@ class AutocompleteControllerTest < ActionDispatch::IntegrationTest
     get autocomplete_path(q: "")
     assert_equal [], response.parsed_body
   end
+
+  test "constant anchor" do
+    get autocomplete_path(q: "SSL_ATTRIBUTES")
+    assert_includes response.parsed_body, {
+      "text" => "Net::HTTP::SSL_ATTRIBUTES",
+      "path" => "/3.4/o/net/http#constant-SSL_ATTRIBUTES"
+    }
+  end
 end

--- a/test/controllers/objects_controller_test.rb
+++ b/test/controllers/objects_controller_test.rb
@@ -50,6 +50,13 @@ class ObjectsControllerTest < ActionDispatch::IntegrationTest
     assert_select "#object-type-label", "Module"
   end
 
+  test "constant anchor" do
+    get object_url object: ruby_objects(:net_http).path
+
+    assert_select 'a[href="#constant-SSL_ATTRIBUTES"]', text: "SSL_ATTRIBUTES"
+    assert_select "#constant-SSL_ATTRIBUTES"
+  end
+
   test "show method sequence" do
     get object_url object: @string.path
 

--- a/test/fixtures/ruby_constants.yml
+++ b/test/fixtures/ruby_constants.yml
@@ -8,5 +8,5 @@
 ssl_attributes:
   name: SSL_ATTRIBUTES
   description: SSL Configuration
-  constant: NET::HTTP::SSL_ATTRIBUTES
+  constant: Net::HTTP::SSL_ATTRIBUTES
   ruby_object: net_http


### PR DESCRIPTION
Search results linking to `RubyConstant` use anchors that do not match rendered ids on the target page, which causes the page not to scroll when clicking the result.  
For example, searching for `SSL_ATTRIBUTES` links to `/4.0/o/net/httpsession#constant-SSL_ATTRIBUTES`, but `id` on the page is `id="SSL_ATTRIBUTES"` missing the `constant-` prefix.

The fix is to use `constant_anchor` helper for rendered constant ids and in-page constant links, so search result URLs and page anchors stay consistent.

---

Btw, should attributes also have an `attribute_anchor` helper? currently they don't have a prefix, `attribute-i-*` or `attribute-c-*`.