### PR TITLE
Update Bundler from 2.4.1 to 4.0.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,7 +547,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 4.0.3p0
+  ruby 4.0.3p0
 
 BUNDLED WITH
-   2.4.1
+  4.0.11


### PR DESCRIPTION
Currently locked bundler version `2.4.1` (4 years old) is printing some warnings when running `bundle` or `bin/dev` commands:
```sh
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:239: warning: already initialized constant Gem::Platform::JAVA
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:279: warning: previous definition of JAVA was here
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:240: warning: already initialized constant Gem::Platform::MSWIN
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:280: warning: previous definition of MSWIN was here
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:241: warning: already initialized constant Gem::Platform::MSWIN64
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:281: warning: previous definition of MSWIN64 was here
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:242: warning: already initialized constant Gem::Platform::MINGW
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:282: warning: previous definition of MINGW was here
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:243: warning: already initialized constant Gem::Platform::X64_MINGW
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:284: warning: previous definition of X64_MINGW was here
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:245: warning: already initialized constant Gem::Platform::WINDOWS
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:286: warning: previous definition of WINDOWS was here
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:246: warning: already initialized constant Gem::Platform::X64_LINUX
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:287: warning: previous definition of X64_LINUX was here
/home/alex/.rbenv/versions/4.0.3/lib/ruby/gems/4.0.0/gems/bundler-2.4.1/lib/bundler/rubygems_ext.rb:247: warning: already initialized constant Gem::Platform::X64_LINUX_MUSL
/home/alex/.rbenv/versions/4.0.3/lib/ruby/4.0.0/rubygems/platform.rb:288: warning: previous definition of X64_LINUX_MUSL was here
```

This PR updates locked bundler with `bundle update --bundler` to change `BUNDLED WITH` version. No warnings after the update. 