### PR TITLE
Fix source code block and toggle button styles

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -24,29 +24,10 @@
     }
 }
 
+/*
+ * Code syntax theme
+ */
 @layer components {
-    pre.ruby {
-        @apply p-3 mb-3 rounded-b rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
-    }
-
-    pre {
-        @apply p-3 rounded bg-gray-300;
-    }
-
-    .dark pre {
-        @apply bg-gray-900;
-    }
-
-    .dark .ruby-documentation dt {
-        @apply bg-gray-900;
-    }
-
-    .dark .ruby-documentation dl,
-    .dark .ruby-documentation dt,
-    .dark .ruby-documentation dd {
-        @apply bg-gray-700;
-    }
-
     .ruby-string {
         color: #99C794;
     }
@@ -85,41 +66,12 @@
     .nf {
         color: #61afef;
     }
+}
 
-    code {
-        padding: 0.15rem;
-        @apply bg-gray-300 rounded leading-relaxed text-sm text-gray-700;
-    }
-
-    .method-src-body {
-        padding: 0;
-        background: none;
-        counter-reset: listing;
-    }
-
-    .method-src-body .line {
-        counter-increment: listing;
-    }
-
-    .method-src-body .line:before {
-        @apply pr-2 mr-3 w-8 text-center border-r-2 border-gray-600 text-gray-600;
-        user-select: none;
-        display: inline-block;
-        content: counter(listing);
-    }
-
-    .dark .method-src-body {
-        background: none;
-    }
-
-    .dark code {
-        @apply bg-gray-700 text-gray-300;
-    }
-
-    pre:not(.ruby) {
-        @apply overflow-auto font-mono;
-    }
-
+/*
+ * RDoc styles
+ */
+@layer components {
     .ruby-documentation ul {
         @apply list-disc list-inside;
     }
@@ -162,12 +114,72 @@
         @apply border-0;
     }
 
+    .dark .ruby-documentation dt {
+        @apply bg-gray-900;
+    }
+
+    .dark .ruby-documentation dl,
+    .dark .ruby-documentation dt,
+    .dark .ruby-documentation dd {
+        @apply bg-gray-700;
+    }
+
     .ruby-documentation h1,
     .ruby-documentation h2,
     .ruby-documentation h3,
     .ruby-documentation h4,
     .ruby-documentation h5 {
         @apply font-semibold text-lg py-1;
+    }
+
+    code {
+        padding: 0.15rem;
+        @apply bg-gray-300 rounded leading-relaxed text-sm text-gray-700;
+    }
+
+    .dark code {
+        @apply bg-gray-700 text-gray-300;
+    }
+
+    pre {
+        @apply p-3 rounded bg-gray-300;
+    }
+
+    .dark pre {
+        @apply bg-gray-900;
+    }
+
+    pre.ruby {
+        @apply p-3 mb-3 rounded-b rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
+    }
+
+    pre:not(.ruby) {
+        @apply overflow-auto font-mono;
+    }
+
+    /*
+     * Method source
+     */
+
+    .method-src-body {
+        padding: 0;
+        background: none;
+        counter-reset: listing;
+    }
+
+    .method-src-body .line {
+        counter-increment: listing;
+    }
+
+    .method-src-body .line:before {
+        @apply pr-2 mr-3 w-8 text-center border-r-2 border-gray-600 text-gray-600;
+        user-select: none;
+        display: inline-block;
+        content: counter(listing);
+    }
+
+    .dark .method-src-body {
+        background: none;
     }
 }
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -132,54 +132,55 @@
         @apply font-semibold text-lg py-1;
     }
 
-    code {
+    /* Inline code */
+    .ruby-documentation code {
         padding: 0.15rem;
         @apply bg-gray-300 rounded leading-relaxed text-sm text-gray-700;
+        @variant dark {
+            @apply bg-gray-700 text-gray-300;
+        }
     }
 
-    .dark code {
-        @apply bg-gray-700 text-gray-300;
+    /* Code block (for unstyled code) */
+    .ruby-documentation pre {
+        @apply p-3 rounded bg-gray-300 overflow-auto font-mono;
+        @variant dark {
+            @apply bg-gray-900;
+        }
     }
 
-    pre {
-        @apply p-3 rounded bg-gray-300;
+    /* Code block (for highlighted code) */
+    .code-block,
+    .ruby-documentation pre.ruby {
+        @apply p-3 mb-3 rounded rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
+        @variant dark {
+            @apply bg-gray-900;
+        }
     }
+}
 
-    .dark pre {
-        @apply bg-gray-900;
-    }
-
-    pre.ruby {
-        @apply p-3 mb-3 rounded-b rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
-    }
-
-    pre:not(.ruby) {
-        @apply overflow-auto font-mono;
-    }
-
+@layer components {
     /*
-     * Method source
+     * Line Numbers (for code blocks)
+     *
+     * Variables:
+     *   --line-numbers-start (optional, default: 1)
+     *
+     * Example:
+     *   <pre class="line-numbers" style="--line-numbers-start: <%= num %>">
+     *     <div class="line">def hello</div>
+     *     <div class="line">  puts "world"</div>
+     *     <div class="line">end</div>
+     *   </pre>
      */
-
-    .method-src-body {
-        padding: 0;
-        background: none;
-        counter-reset: listing;
-    }
-
-    .method-src-body .line {
-        counter-increment: listing;
-    }
-
-    .method-src-body .line:before {
-        @apply pr-2 mr-3 w-8 text-center border-r-2 border-gray-600 text-gray-600;
-        user-select: none;
-        display: inline-block;
-        content: counter(listing);
-    }
-
-    .dark .method-src-body {
-        background: none;
+    .line-numbers {
+        counter-reset: lines calc(max(var(--line-numbers-start, 1), 1) - 1);
+        & .line::before {
+            counter-increment: lines;
+            content: counter(lines);
+            min-width: 5ch;
+            @apply pr-2 mr-3 text-right border-r-2 border-gray-600 text-gray-600 select-none inline-block;
+        }
     }
 }
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -83,16 +83,8 @@ p {
     @apply my-3;
 }
 
-.overflow-wrap-break-word {
-    overflow-wrap: break-word;
-}
-
 .h-93 {
     height: calc(100vh - 7rem) !important;
-}
-
-.h-94 {
-    height: calc(100vh - 6rem) !important;
 }
 
 code {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -18,155 +18,162 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-pre.ruby {
-    @apply p-3 mb-3 rounded-b rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
+@layer base {
+    p {
+        @apply my-3;
+    }
 }
 
-pre {
-    @apply p-3 rounded bg-gray-300;
+@layer components {
+    pre.ruby {
+        @apply p-3 mb-3 rounded-b rounded-t-none overflow-auto font-mono bg-code-background text-code-text;
+    }
+
+    pre {
+        @apply p-3 rounded bg-gray-300;
+    }
+
+    .dark pre {
+        @apply bg-gray-900;
+    }
+
+    .dark .ruby-documentation dt {
+        @apply bg-gray-900;
+    }
+
+    .dark .ruby-documentation dl,
+    .dark .ruby-documentation dt,
+    .dark .ruby-documentation dd {
+        @apply bg-gray-700;
+    }
+
+    .ruby-string {
+        color: #99C794;
+    }
+
+    .ruby-keyword,
+    .k,
+    .kt {
+        color: #c678dd;
+    }
+
+    .ruby-comment,
+    .c1 {
+        color: #65737e;
+    }
+
+    .ruby-constant,
+    .mi {
+        color: #e5c07b;
+    }
+
+    .ruby-identifier,
+    .o {
+        color: #ec5f67;
+    }
+
+    .ruby-value {
+        color: #F99157;
+    }
+
+    .ruby-regexp,
+    .sr {
+        color: #98c379;
+    }
+
+    .ruby-operator,
+    .nf {
+        color: #61afef;
+    }
+
+    code {
+        padding: 0.15rem;
+        @apply bg-gray-300 rounded leading-relaxed text-sm text-gray-700;
+    }
+
+    .method-src-body {
+        padding: 0;
+        background: none;
+        counter-reset: listing;
+    }
+
+    .method-src-body .line {
+        counter-increment: listing;
+    }
+
+    .method-src-body .line:before {
+        @apply pr-2 mr-3 w-8 text-center border-r-2 border-gray-600 text-gray-600;
+        user-select: none;
+        display: inline-block;
+        content: counter(listing);
+    }
+
+    .dark .method-src-body {
+        background: none;
+    }
+
+    .dark code {
+        @apply bg-gray-700 text-gray-300;
+    }
+
+    pre:not(.ruby) {
+        @apply overflow-auto font-mono;
+    }
+
+    .ruby-documentation ul {
+        @apply list-disc list-inside;
+    }
+
+    .ruby-documentation ul li {
+        @apply my-1;
+    }
+
+    .ruby-documentation ul li p {
+        @apply inline;
+    }
+
+    .ruby-documentation ol {
+        @apply list-decimal list-inside;
+    }
+
+    .ruby-documentation ol li p {
+        @apply inline-block my-1;
+    }
+
+    .ruby-documentation dd,
+    .ruby-documentation dt {
+        @apply w-full text-center;
+    }
+
+    .ruby-documentation dl {
+        @apply flex flex-wrap border-2 border-gray-400;
+    }
+
+    .ruby-documentation dd {
+        @apply px-3;
+    }
+
+    .ruby-documentation dt {
+        @apply py-3 bg-gray-300;
+    }
+
+    .ruby-documentation dt:last-of-type,
+    .ruby-documentation dd:last-of-type {
+        @apply border-0;
+    }
+
+    .ruby-documentation h1,
+    .ruby-documentation h2,
+    .ruby-documentation h3,
+    .ruby-documentation h4,
+    .ruby-documentation h5 {
+        @apply font-semibold text-lg py-1;
+    }
 }
 
-.dark pre {
-    @apply bg-gray-900;
-}
-
-.dark .ruby-documentation dt {
-    @apply bg-gray-900;
-}
-
-.dark .ruby-documentation dl,
-.dark .ruby-documentation dt,
-.dark .ruby-documentation dd {
-    @apply bg-gray-700;
-}
-
-.ruby-string {
-    color: #99C794;
-}
-
-.ruby-keyword,
-.k,
-.kt {
-    color: #c678dd;
-}
-
-.ruby-comment,
-.c1 {
-    color: #65737e;
-}
-
-.ruby-constant,
-.mi {
-    color: #e5c07b;
-}
-
-.ruby-identifier,
-.o {
-    color: #ec5f67;
-}
-
-.ruby-value {
-    color: #F99157;
-}
-
-.ruby-regexp,
-.sr {
-    color: #98c379;
-}
-
-.ruby-operator,
-.nf {
-    color: #61afef;
-}
-
-p {
-    @apply my-3;
-}
-
-.h-93 {
-    height: calc(100vh - 7rem) !important;
-}
-
-code {
-    padding: 0.15rem;
-    @apply bg-gray-300 rounded leading-relaxed text-sm text-gray-700;
-}
-
-.method-src-body {
-    padding: 0;
-    background: none;
-    counter-reset: listing;
-}
-
-.method-src-body .line {
-    counter-increment: listing;
-}
-
-.method-src-body .line:before {
-    @apply pr-2 mr-3 w-8 text-center border-r-2 border-gray-600 text-gray-600;
-    user-select: none;
-    display: inline-block;
-    content: counter(listing);
-}
-
-.dark .method-src-body {
-    background: none;
-}
-
-.dark code {
-    @apply bg-gray-700 text-gray-300;
-}
-
-pre:not(.ruby) {
-    @apply overflow-auto font-mono;
-}
-
-.ruby-documentation ul {
-    @apply list-disc list-inside;
-}
-
-.ruby-documentation ul li {
-    @apply my-1;
-}
-
-.ruby-documentation ul li p {
-    @apply inline;
-}
-
-.ruby-documentation ol {
-    @apply list-decimal list-inside;
-}
-
-.ruby-documentation ol li p {
-    @apply inline-block my-1;
-}
-
-.ruby-documentation dd,
-.ruby-documentation dt {
-    @apply w-full text-center;
-}
-
-.ruby-documentation dl {
-    @apply flex flex-wrap border-2 border-gray-400;
-}
-
-.ruby-documentation dd {
-    @apply px-3;
-}
-
-.ruby-documentation dt {
-    @apply py-3 bg-gray-300;
-}
-
-.ruby-documentation dt:last-of-type,
-.ruby-documentation dd:last-of-type {
-    @apply border-0;
-}
-
-.ruby-documentation h1,
-.ruby-documentation h2,
-.ruby-documentation h3,
-.ruby-documentation h4,
-.ruby-documentation h5 {
-    @apply font-semibold text-lg py-1;
+@layer utilities {
+    /* sidebar height */
+    .h-93 {
+        height: calc(100vh - 7rem) !important;
+    }
 }

--- a/app/javascript/controllers/method_controller.js
+++ b/app/javascript/controllers/method_controller.js
@@ -5,12 +5,20 @@ export default class extends Controller {
 
   toggleShowSource(event) {
     event.preventDefault()
+    this.#toggleAttrValue(this.showSrcBodyButtonTarget, "aria-pressed", "true", "false")
+    this.srcBodyTarget.toggleAttribute("data-open")
+  }
 
-    this.showSrcBodyButtonTarget.classList.toggle("bg-blue-600")
-    this.showSrcBodyButtonTarget.classList.toggle("text-white")
-    this.showSrcBodyButtonTarget.classList.toggle("hover:bg-blue-700")
-    this.showSrcBodyButtonTarget.classList.toggle("hover:text-white-300")
-    this.showSrcBodyButtonTarget.classList.toggle("dark:bg-gray-900")
-    this.srcBodyTarget.classList.toggle("hidden")
+  // Toggles an attribute between two values.
+  //
+  //   this.#toggleAttrValue(el, "data-state", "active", "inactive")
+  //
+  #toggleAttrValue(element, attr, toggleValue, initValue) {
+    const shouldToggle = element.getAttribute(attr) !== toggleValue
+    if (shouldToggle) {
+      element.setAttribute(attr, toggleValue)
+    } else {
+      element.setAttribute(attr, initValue)
+    }
   }
 }

--- a/app/views/objects/show/_methods.html.erb
+++ b/app/views/objects/show/_methods.html.erb
@@ -62,7 +62,26 @@
             <%= m.type_identifier %>
           </span>
 
-          <%= button_tag class: "px-1 ml-2 h-6 inline-block rounded bg-gray-200 dark:bg-gray-700 align-middle hover:bg-gray-300 dark-hover:bg-gray-900 dark-hover:text-gray-400 hover:fill-current disabled:opacity-50 disabled:cursor-default", title: "Show Source Code", disabled: m.is_alias?, data: { "method-target" => "showSrcBodyButton", "action" => "click->method#toggleShowSource" } do %>
+          <button
+            class="
+              bg-gray-200 px-1 ml-2 h-6 inline-block rounded align-middle cursor-pointer
+              hover:bg-gray-300 hover:fill-current
+              aria-pressed:text-white aria-pressed:bg-gray-500 aria-pressed:hover:bg-gray-500
+              disabled:opacity-50 disabled:bg-gray-300 disabled:cursor-default
+              dark:bg-gray-700 dark:disabled:bg-gray-700 dark:hover:bg-gray-600
+              dark:aria-pressed:text-white dark:aria-pressed:bg-gray-900 dark:aria-pressed:hover:bg-gray-900
+            "
+            type="button"
+            aria-pressed="false"
+            <% if m.is_alias? %>
+              title="No Source Code"
+              disabled=""
+            <% else %>
+              title="Show Source Code"
+              data-action="click->method#toggleShowSource"
+              data-method-target="showSrcBodyButton"
+            <% end %>
+          >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="h-5 w-5"
@@ -75,11 +94,11 @@
                 clip-rule="evenodd"
               ></path>
             </svg>
-          <% end %>
+          </button>
         </div>
       </div>
 
-      <div class="hidden my-2" data-method-target="srcBody">
+      <div class="hidden data-open:block my-2" data-method-target="srcBody">
         <div
           class="
             w-full px-3 py-2 bg-code-header dark:bg-gray-700 items-center
@@ -98,7 +117,7 @@
             View on GitHub
             <svg
               xmlns="http://www.w3.org/2000/svg"
-              class="inline h-5 w-5"
+              class="inline h-5 w-5 mb-1"
               viewBox="0 0 20 20"
               fill="currentColor"
             >

--- a/app/views/objects/show/_methods.html.erb
+++ b/app/views/objects/show/_methods.html.erb
@@ -113,9 +113,10 @@
           </a>
         </div>
 
-        <pre class="p-3 rounded-t-none bg-code-background">
-          <code class="method-src-body text-code-text"><%= raw m.source_body %>        </code>
-        </pre>
+        <pre
+          class="code-block line-numbers py-4 text-sm"
+          style="--line-numbers-start: <%= m.source_line %>"
+        ><code><%= raw m.source_body %></code></pre>
       </div>
 
       <div class="ruby-documentation py-1">


### PR DESCRIPTION
This ended up a little bit of a big change. I didn't squish the commits for easier review.

Issues:
- Source code block is hard to see in light mode
- Unintended whitespace inside the `pre` tag
- Source code button dark hover and pressed styles are not consistent with the light theme. Dark hover looks broken.

Changes:
- Remove unused styles `.h-94`, `.overflow-wrap-break-word`
- Organize styles into layers to avoid specificity issues with tailwind utility classes
- Unify `.method-src-body` and rdoc's `pre.ruby` into `.code-block` to keep styles consistent with documentation code blocks
- Add `.line-numbers` class to show line numbers for code blocks, optionally supporting the starting line number via `--line-numbers-start` css variable.
- Move styling responsibility out of `method_controller.js` into html using `data-*` and `aria-*` attributes
- Use `data-open:*` and `aria-pressed:*` selectors to style the toggle button. This keeps all the styles in one place, leaving javascript to only manage state.

| Before | After |
|--------|--------|
| <img width="953" height="366" alt="Image" src="https://github.com/user-attachments/assets/763ce270-1a13-405b-b608-810dde6171e3" />  | <img width="953" height="366" alt="Image" src="https://github.com/user-attachments/assets/876e48df-7a7e-4f6f-98dc-a244b5097b34" /> |
| <img width="953" height="366" alt="Image" src="https://github.com/user-attachments/assets/669569d7-e665-4e84-8c57-e1c91b2a4a3a" /> | <img width="953" height="366" alt="Image" src="https://github.com/user-attachments/assets/d8c8e301-8419-4495-927d-1ac7feb144ad" />| 
| <img width="256" height="186" alt="Image" src="https://github.com/user-attachments/assets/65c572d1-3de2-4a3e-85ec-bd8a3d01c0a7" /> | <img width="256" height="186" alt="Image" src="https://github.com/user-attachments/assets/e0e2d70d-aa54-4451-a300-8878cc8b38a3" /> |
| <img width="256" height="186" alt="Image" src="https://github.com/user-attachments/assets/5b49e664-ec68-46ce-9522-178036d9ea3e" /> | <img width="256" height="186" alt="Image" src="https://github.com/user-attachments/assets/51f13682-3396-45a0-a687-ea4113a3393b" /> |

Fixes #2401