### PR TITLE
Fix "View on github" links

### DIFF
--- a/app/models/ruby_method.rb
+++ b/app/models/ruby_method.rb
@@ -51,11 +51,11 @@ class RubyMethod < ApplicationRecord
   end
 
   def source_file
-    source_properties.first
+    source_properties.second
   end
 
   def source_line
-    source_properties.second.to_i
+    source_properties.third.to_i
   end
 
   private

--- a/test/fixtures/ruby_methods.yml
+++ b/test/fixtures/ruby_methods.yml
@@ -9,7 +9,7 @@ to_i:
   name: to_i
   description: Returns the integer representation of the object.
   method_type: instance
-  source_location: string.c:123
+  source_location: 3.4:string.c:123
   constant: String#to_i
   call_sequences:
     - "str.to_i # => 1"
@@ -25,7 +25,7 @@ to_str:
   name: to_str
   description: Returns self if self is a String.
   method_type: instance
-  source_location: string.c:456
+  source_location: 3.4:string.c:456
   constant: String#to_str
   call_sequences:
     - "to_str"

--- a/test/models/ruby_method_test.rb
+++ b/test/models/ruby_method_test.rb
@@ -38,7 +38,7 @@ class RubyMethodTest < ActiveSupport::TestCase
   end
 
   test "source file and line" do
-    method = RubyMethod.new(source_location: "path/to/file.rb:42")
+    method = RubyMethod.new(source_location: "3.4:path/to/file.rb:42")
 
     assert_equal "path/to/file.rb", method.source_file
     assert_equal 42, method.source_line


### PR DESCRIPTION
This fixes broken "View on GitHub" links. The extra version prefix in source_location `4.0:` was not taken into account.
https://github.com/rubyapi/rubyapi/blob/4d71c1719612cd83bc05e6765abe2bc39d30b5ab/lib/rubyapi_rdoc_generator.rb#L60

`github_url` already has [test](https://github.com/rubyapi/rubyapi/blob/ca9b0d10a2d8d543be190759c7858266df2da338/test/helpers/application_helper_test.rb#L11-L18) coverage.

Fixes #2391