### PR TITLE
Fix missing parents when superclass is namespaced

### DIFF
--- a/lib/rubyapi_rdoc_generator.rb
+++ b/lib/rubyapi_rdoc_generator.rb
@@ -166,7 +166,7 @@ class RubyAPIRDocGenerator
     if doc.superclass.is_a?(String)
       doc.superclass
     else
-      doc.superclass.name
+      doc.superclass.full_name
     end
   end
 end

--- a/test/fixtures/doc/namespaced_superclass.rb
+++ b/test/fixtures/doc/namespaced_superclass.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Namespaced
+  class Parent
+  end
+
+  class Child < Parent
+  end
+end

--- a/test/lib/rubyapi_rdoc_generator_test.rb
+++ b/test/lib/rubyapi_rdoc_generator_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyAPIRDocGeneratorTest < ActiveSupport::TestCase
+  test "namespaced superclass association" do
+    document "namespaced_superclass.rb"
+    object = RubyObject.find_by!(constant: "Namespaced::Child")
+
+    assert_equal "Namespaced::Parent", object.superclass_constant
+    assert object.superclass
+  end
+
+  private
+
+  # Documents files with RubyAPIRDocGenerator.
+  #
+  #   document "test_class.rb"
+  #   assert RubyObject.find_by(constant: "TestClass")
+  #
+  # Returns an RDoc::RDoc instance.
+  #
+  #   rdoc = document "test_class.rb"
+  #   rdoc.store.all_classes_and_modules
+  #
+  def document(
+    path, # file, dir, glob
+    release: RubyRelease.new(version: "test", signatures: false),
+    root: "test/fixtures/doc",
+    visibility: :private, # :private, :protected
+    verbosity: 0 # 0, 1, 2
+  )
+    opts = RDoc::Options.load_options.tap do |options|
+      options.generator = RubyAPIRDocGenerator
+      options.generator_options = [ release ]
+      options.root = Rails.root.join(root).to_s
+      options.files = Rails.root.join(root).glob(path).map(&:to_s)
+      options.op_dir = Rails.root.join("tmp/rdoc_test").to_s
+      options.visibility = visibility
+      options.verbosity = verbosity
+      options.template = ""
+    end
+    RDoc::RDoc.new.tap do |rdoc|
+      rdoc.document(opts)
+    end
+  end
+end

--- a/test/lib/rubyapi_rdoc_generator_test.rb
+++ b/test/lib/rubyapi_rdoc_generator_test.rb
@@ -8,40 +8,22 @@ class RubyAPIRDocGeneratorTest < ActiveSupport::TestCase
     object = RubyObject.find_by!(constant: "Namespaced::Child")
 
     assert_equal "Namespaced::Parent", object.superclass_constant
-    assert object.superclass
+    assert_equal RubyObject.find_by!(constant: "Namespaced::Parent"), object.superclass
   end
 
   private
 
-  # Documents files with RubyAPIRDocGenerator.
-  #
-  #   document "test_class.rb"
-  #   assert RubyObject.find_by(constant: "TestClass")
-  #
-  # Returns an RDoc::RDoc instance.
-  #
-  #   rdoc = document "test_class.rb"
-  #   rdoc.store.all_classes_and_modules
-  #
-  def document(
-    path, # file, dir, glob
-    release: RubyRelease.new(version: "test", signatures: false),
-    root: "test/fixtures/doc",
-    visibility: :private, # :private, :protected
-    verbosity: 0 # 0, 1, 2
-  )
+  def document(filename)
     opts = RDoc::Options.load_options.tap do |options|
       options.generator = RubyAPIRDocGenerator
-      options.generator_options = [ release ]
-      options.root = Rails.root.join(root).to_s
-      options.files = Rails.root.join(root).glob(path).map(&:to_s)
+      options.generator_options = [ RubyRelease.new(version: "test", signatures: false) ]
+      options.root = Rails.root.join("test/fixtures/doc").to_s
+      options.files = [ Rails.root.join("test/fixtures/doc", filename).to_s ]
       options.op_dir = Rails.root.join("tmp/rdoc_test").to_s
-      options.visibility = visibility
-      options.verbosity = verbosity
+      options.visibility = :private
+      options.verbosity = 0
       options.template = ""
     end
-    RDoc::RDoc.new.tap do |rdoc|
-      rdoc.document(opts)
-    end
+    RDoc::RDoc.new.document(opts)
   end
 end


### PR DESCRIPTION
This PR fixes missing parent objects by using full object name for `RubyObject#superclass_constant` attribute, which will match `constant` attribute expected in the `superclass` association. 

https://github.com/rubyapi/rubyapi/blob/06052ae72281be05a4065b97cd87e10a5cc210cc/lib/rubyapi_rdoc_generator.rb#L169

Using `doc.superclass.full_name` fixes almost all of the missing associations:

```rb
# before (v4.0 only)
RubyObject.where.missing(:superclass).where(object_type: "class_object").size #=> 586 

# after (v4.0 only)
RubyObject.where.missing(:superclass).where(object_type: "class_object").size #=> 39
```

Example: https://rubyapi.org/4.0/o/net/http/get should show `Net::HTTPRequest` as its parent. 

| Before | After |
|--------|--------|
| <img width="542" height="363" alt="Screenshot from 2026-05-22 15-32-02" src="https://github.com/user-attachments/assets/f505eb6b-c2fa-43de-bfa6-bb9b664902b9" /> | <img width="542" height="363" alt="Screenshot from 2026-05-22 15-34-46" src="https://github.com/user-attachments/assets/87f08931-a1e2-4295-836b-44da712759ad" /> |

Fixes #2394
Fixes #1229