### PR TITLE
Speed up tests from ~90s to ~5s

### DIFF
--- a/test/config/aws_config_test.rb
+++ b/test/config/aws_config_test.rb
@@ -20,13 +20,23 @@ class AwsConfigTest < ActiveSupport::TestCase
   end
 
   test "with ecs aws credential provider" do
+    stub_request(:get, "http://169.254.170.2/test/path").to_return(
+      status: 200,
+      body: {
+        AccessKeyId: "<access_key_id>",
+        SecretAccessKey: "<secret_access_key>",
+        Token: "<session_token>"
+      }.to_json
+    )
+
     with_env(
       "AWS_AUTHENTICATION_PROVIDER" => "ecs"
     ) do
-      capture_subprocess_io do
-        credentials = AwsConfig.new.credentials
-        assert_kind_of Aws::Credentials, credentials
-      end
+      credentials = AwsConfig.new.credentials
+      assert_kind_of Aws::Credentials, credentials
+      assert_equal "<access_key_id>", credentials.access_key_id
+      assert_equal "<secret_access_key>", credentials.secret_access_key
+      assert_equal "<session_token>", credentials.session_token
     end
   end
 end

--- a/test/controllers/autocomplete_controller_test.rb
+++ b/test/controllers/autocomplete_controller_test.rb
@@ -3,6 +3,14 @@
 require "test_helper"
 
 class AutocompleteControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    reindex_search_models
+  end
+
+  teardown do
+    delete_search_index
+  end
+
   test "should get index" do
     get autocomplete_path(q: "new")
     assert_response :success

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require "webmock/minitest"
 
 Rails.root.glob("lib/*.rb").each { |f| require_relative f }
 
-WebMock.disable!
+WebMock.disable_net_connect!(allow_localhost: true)
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,21 +19,16 @@ class ActiveSupport::TestCase
 
   fixtures :all
 
-  def setup
-    Current.theme = ThemeConfig.theme_for("light")
-    Current.ruby_release = ruby_releases(:latest)
-    Current.default_ruby_release = ruby_releases(:latest)
+  SEARCH_MODELS = [ RubyObject, RubyMethod, RubyConstant ].freeze
 
-    # reindex models
-    RubyObject.reindex
-    RubyMethod.reindex
-    RubyConstant.reindex
-
-    # and disable callbacks
+  def reindex_search_models
+    SEARCH_MODELS.each(&:reindex)
     Searchkick.disable_callbacks
   end
 
-  def default_ruby_release
-    ruby_releases(:latest)
+  def delete_search_index
+    SEARCH_MODELS.each do |model|
+      model.search_index.delete
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require "webmock/minitest"
 Rails.root.glob("lib/*.rb").each { |f| require_relative f }
 
 WebMock.disable_net_connect!(allow_localhost: true)
+Searchkick.disable_callbacks
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
@@ -23,7 +24,6 @@ class ActiveSupport::TestCase
 
   def reindex_search_models
     SEARCH_MODELS.each(&:reindex)
-    Searchkick.disable_callbacks
   end
 
   def delete_search_index


### PR DESCRIPTION
**Issues:**

- AWS test hits outside network costing ~70s
- Running reindex for every test costs ~2s

```sh
AwsConfigTest#test_with_ecs_aws_credential_provider = 77.71 s = .
RubyMethodTest#test_source_file_and_line = 2.95 s = .
```

**Changes:**

- Stub AWS test request
- Remove global `setup`, `reindex` is not required for most of the tests, setting `Current` attributes is not needed. (If you accidentally hit search in your test without reindexing a `Searchkick::MissingIndexError` is raised, so this change should be safe.)
- Only run `reindex` when testing search with `reindex_search_models` helper.
- Clean up test indices with `delete_search_index` helper.

```sh
AwsConfigTest#test_with_ecs_aws_credential_provider = 0.02 s = .
RubyMethodTest#test_source_file_and_line = 0.01 s = .
```
---

Before (~90s):
```sh
$ bin/rails test
Running 55 tests in parallel using 4 processes
.......................................................

Finished in 96.078060s, 0.5725 runs/s, 1.2282 assertions/s.
55 runs, 118 assertions, 0 failures, 0 errors, 0 skips
```

After (~5s):
```sh
$ bin/rails test
Running 55 tests in parallel using 4 processes
.......................................................

Finished in 5.266942s, 10.4425 runs/s, 22.9735 assertions/s.
55 runs, 121 assertions, 0 failures, 0 errors, 0 skips
```

Before (model tests ~15s):

```sh
$ bin/rails test test/models
Running 14 tests in a single process (parallelization threshold is 50)
..............
Finished in 15.816915s, 0.8851 runs/s, 2.2760 assertions/s.
14 runs, 36 assertions, 0 failures, 0 errors, 0 skips
```

After (model tests ~0.5s):

```sh
$ bin/rails test test/models
Running 14 tests in a single process (parallelization threshold is 50)
..............
Finished in 0.646985s, 21.6388 runs/s, 55.6428 assertions/s.
14 runs, 36 assertions, 0 failures, 0 errors, 0 skips
```