### PR TITLE
Upgrade OpenSearch to 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,13 +44,14 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       search:
-        image: opensearchproject/opensearch:2.11.0
+        image: opensearchproject/opensearch:3.5.0
         ports:
           - 9200:9200
         env:
           "discovery.type": "single-node"
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: RubyApi-Local-OpenSearch-2026!
         options: >-
-          --health-cmd "curl -u admin:admin --silent --fail --insecure https://localhost:9200/_cluster/health || exit 1"
+          --health-cmd "curl -u admin:RubyApi-Local-OpenSearch-2026! --silent --fail --insecure https://localhost:9200/_cluster/health || exit 1"
           --health-start-period 30s
           --health-interval 10s
           --health-timeout 5s
@@ -93,13 +94,14 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       search:
-        image: opensearchproject/opensearch:2.11.0
+        image: opensearchproject/opensearch:3.5.0
         ports:
           - 9200:9200
         env:
           "discovery.type": "single-node"
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: RubyApi-Local-OpenSearch-2026!
         options: >-
-          --health-cmd "curl -u admin:admin --silent --fail --insecure https://localhost:9200/_cluster/health || exit 1"
+          --health-cmd "curl -u admin:RubyApi-Local-OpenSearch-2026! --silent --fail --insecure https://localhost:9200/_cluster/health || exit 1"
           --health-start-period 30s
           --health-interval 10s
           --health-timeout 5s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ A fast, mobile-friendly documentation browser for the Ruby standard library and 
 - `bin/rubocop` — lint with RuboCop (rubocop-rails-omakase config)
 - `bin/ci` — full CI suite (rubocop, bundler-audit, importmap audit, brakeman, tests, seed replant)
 - `bin/rails import:ruby[3.4]` — import documentation for a specific Ruby version
-- `docker compose up -d` — start PostgreSQL 17 + OpenSearch 2.11. Canonical local setup; running them via Homebrew services also works if you already do that.
+- `docker compose up -d` — start PostgreSQL 17 + OpenSearch 3.5. Canonical local setup; running them via Homebrew services also works if you already do that.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ bin/setup            # install gems, copy database.yml, prepare the database
 bin/dev              # start the Rails server on port 3000
 ```
 
+The local OpenSearch API is available at `https://localhost:9200`, and OpenSearch
+Dashboards is available at `http://localhost:5601`. Both use the username `admin`
+and password `RubyApi-Local-OpenSearch-2026!`. These credentials are only for
+local development; the services are bound to the loopback interface and must not
+be exposed publicly.
+
 `bin/setup` is also what you run when you pull updates: it refreshes gems and applies new migrations.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -30,11 +30,9 @@ bin/setup            # install gems, copy database.yml, prepare the database
 bin/dev              # start the Rails server on port 3000
 ```
 
-The local OpenSearch API is available at `https://localhost:9200`, and OpenSearch
+OpenSearch is available at `https://localhost:9200`, and OpenSearch
 Dashboards is available at `http://localhost:5601`. Both use the username `admin`
-and password `RubyApi-Local-OpenSearch-2026!`. These credentials are only for
-local development; the services are bound to the loopback interface and must not
-be exposed publicly.
+and password `RubyApi-Local-OpenSearch-2026!`.
 
 `bin/setup` is also what you run when you pull updates: it refreshes gems and applies new migrations.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,34 +1,37 @@
 services:
   search:
-    image: opensearchproject/opensearch:2.11.0
+    image: opensearchproject/opensearch:3.5.0
     ports:
-      - "9600:9600"
-      - "9200:9200"
+      - "127.0.0.1:9600:9600"
+      - "127.0.0.1:9200:9200"
     environment:
       - discovery.type=single-node
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=RubyApi-Local-OpenSearch-2026!
     volumes:
       - search-data:/usr/share/opensearch/data
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl -u admin:admin --fail --silent --insecure https://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=50s || exit 1",
+          "curl -u admin:RubyApi-Local-OpenSearch-2026! --fail --silent --insecure https://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=50s || exit 1",
         ]
       retries: 3
       interval: 5s
       timeout: 3s
 
   search-console:
-    image: opensearchproject/opensearch-dashboards:2.11.0
+    image: opensearchproject/opensearch-dashboards:3.5.0
     ports:
-      - "5601:5601"
+      - "127.0.0.1:5601:5601"
     environment:
       OPENSEARCH_HOSTS: '["https://search:9200"]'
+      OPENSEARCH_USERNAME: admin
+      OPENSEARCH_PASSWORD: RubyApi-Local-OpenSearch-2026!
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "curl -u admin:admin --fail --silent http://localhost:5601/api/status || exit 1",
+          "curl -u admin:RubyApi-Local-OpenSearch-2026! --fail --silent http://localhost:5601/api/status || exit 1",
         ]
       interval: 5s
       timeout: 3s
@@ -39,7 +42,7 @@ services:
   postgres:
     image: postgres:17-alpine
     ports:
-      - "${DB_PORT:-5432}:5432"
+      - "127.0.0.1:${DB_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: rubyapi
       POSTGRES_PASSWORD: rubyapi_password

--- a/config/opensearch.yml
+++ b/config/opensearch.yml
@@ -1,5 +1,5 @@
 development:
-  url: https://admin:admin@localhost:9200
+  url: https://admin:RubyApi-Local-OpenSearch-2026!@localhost:9200
 
 test:
-  url: https://admin:admin@localhost:9200
+  url: https://admin:RubyApi-Local-OpenSearch-2026!@localhost:9200


### PR DESCRIPTION
Supersedes #2431 with the OpenSearch upgrade rebased onto current `main`.

## Summary

- upgrade OpenSearch and OpenSearch Dashboards from 2.11.0 to 3.5.0, matching the latest engine currently supported by Amazon OpenSearch Service
- retain the demo Security plugin for development and CI so Rails exercises authenticated HTTPS
- use a strong, explicitly local admin credential and document it for developers
- bind all Compose host ports to loopback
- leave Ruby documentation import and Searchkick index lifecycle behavior unchanged for the upcoming gem documentation pipeline

## Verification

- OpenSearch 3.5.0 and Dashboards 3.5.0 started cleanly in isolated containers
- unauthenticated HTTPS returned 401, authenticated HTTPS returned 200, and plaintext HTTP was rejected
- authenticated Dashboard login reached the home application and rendered correctly
- `bin/ci` passed against OpenSearch 3.5.0: 56 tests, 123 assertions, 0 failures
- Compose configuration, YAML parsing, and `git diff --check` passed

## Upgrade note

A local `search-data` volume already opened by OpenSearch 3.8 cannot safely be downgraded. Recreate only that disposable search volume before starting 3.5, preserving PostgreSQL data. Amazon OpenSearch Service production upgrades from 2.11 require the managed 2.11 → 2.19 → 3.5 path.